### PR TITLE
Graceful shutdown (fixes #16)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -229,9 +229,12 @@ exports.worker = function worker (argv) {
         // Handle delay in the case we don't have any queues
         if (result === 'noQueues') {
           const roundDelay = Math.max(1000, options['wait-time'] * 1000)
-          if (!options.quiet) {
-            console.error(chalk.yellow('No queues to listen on! Retrying in ' + (roundDelay / 1000) + 's'))
+          if (!options.quiet) console.error(chalk.yellow('No queues to listen on!'))
+          if (options.drain) {
+            console.error(chalk.blue('Shutting down because we are in drain mode and no work is available.'))
+            return Promise.resolve()
           }
+          console.error(chalk.yellow('Retrying in ' + (roundDelay / 1000) + 's'))
           return Q.delay(roundDelay).then(workLoop)
         }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,7 +26,7 @@ const globalOptionDefinitions = [
   { name: 'prefix', type: String, defaultValue: 'qdone_', description: 'Prefix to place at the front of each SQS queue name [default: qdone_]' },
   { name: 'fail-suffix', type: String, defaultValue: '_failed', description: 'Suffix to append to each queue to generate fail queue name [default: _failed]' },
   { name: 'region', type: String, defaultValue: 'us-east-1', description: 'AWS region for Queues [default: us-east-1]' },
-  { name: 'quiet', alias: 'q', type: Boolean, defaultValue: !process.stdout.isTTY, description: 'Less verbose output suitible for production logging. Automatically set if stdout is not a tty.' },
+  { name: 'quiet', alias: 'q', type: Boolean, defaultValue: !process.stdout.isTTY, description: 'Less verbose output suitable for production logging. Automatically set if stdout is not a tty.' },
   { name: 'version', alias: 'V', type: Boolean, description: 'Show version number' },
   { name: 'help', type: Boolean, description: 'Print full help message.' }
 ]

--- a/src/worker.js
+++ b/src/worker.js
@@ -206,15 +206,8 @@ exports.listen = function listen (queues, options) {
         return oneRound()
       }
 
-      // Otherwise, if we are draining, we are done
-      if (options.drain) return Promise.resolve('noJobs')
-
-      // Otherwise, start the next round at a delay
-      const roundDelay = Math.max(1000, options['wait-time'] * 1000)
-      if (!options.quiet) {
-        console.error(chalk.yellow('No queues to listen on! Retrying in ' + (roundDelay / 1000) + 's'))
-      }
-      return Q.delay(roundDelay).then(oneRound)
+      // Otherwise, let caller know
+      return Promise.resolve('noQueues')
     })
 }
 

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -659,7 +659,7 @@ describe('cli', function () {
         callback(null, {})
       })
     })
-    it('should execute the job successfully and exit 0',
+    it('should begin executing the job, acknowledge a SIGTERM and successfully and exit 0 after the job completes',
       cliTest(['worker', 'test'], function (result, stdout, stderr) {
         expect(stderr).to.contain('Looking for work on test')
         expect(stderr).to.contain('Found job da68f62c-0c07-4bee-bf5f-7e856EXAMPLE')

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -635,41 +635,4 @@ describe('cli', function () {
       }))
   })
 
-/*
-  describe('qdone worker test --wait-time 15', function () {
-    it('should call worker listen loop with a wait time of 15', function () {
-      const cli = require('../src/cli')
-      const worker = require('../src/worker')
-      sandbox.stub(worker, 'listen', _ => Promise.resolve())
-      const result = cli.run(['worker', 'test', '--wait-time', '15'])
-      expect(worker.listen.calledWithMatch('testy', sinon.match.has('wait-time', 15)))
-      return result.then(_ => sandbox.restore())
-    })
-  })
-
-  describe('qdone worker test --drain # (test extension of message visibility timeout)', function () {
-    before(function () {
-      AWS.mock('SQS', 'getQueueUrl', function (params, callback) {
-        callback(null, {QueueUrl: `https://q.amazonaws.com/123456789101/${params.QueueName}`})
-      })
-      AWS.mock('SQS', 'listQueues', function (params, callback) {
-        callback(null, {QueueUrls: [`https://q.amazonaws.com/123456789101/${params.QueueName}`]})
-      })
-      AWS.mock('SQS', 'receiveMessage', function (params, callback) {
-        callback(null, { Messages: [
-          { MessageId: 'da68f62c-0c07-4bee-bf5f-7e856EXAMPLE', Body: 'sleep 35', ReceiptHandle: 'AQEBzbVv...fqNzFw==' }
-        ] })
-      })
-      AWS.mock('SQS', 'deleteMessage', function (params, callback) {
-        callback(null, {})
-      })
-    })
-    it('should execute the job successfully, extend once and exit 0',
-      cliTest(['worker', 'test', '--drain'], function (result, stdout, stderr) {
-        expect(stderr).to.contain('Looking for work on test')
-        expect(stderr).to.contain('Found job da68f62c-0c07-4bee-bf5f-7e856EXAMPLE')
-        expect(stderr).to.contain('SUCCESS')
-      }))
-  })
-*/
 })


### PR DESCRIPTION
This PR changes the behavior of shutdown for qdone. Formerly, SIGINT and SIGTERM caused qdone to exit even if running a job, now they will cause it to exit only after a running job finishes or times out.