### PR TITLE
fix #25

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "qdone",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0",
   "dependencies": {
     "ansi-styles": {
       "version": "3.2.1",
@@ -173,6 +173,11 @@
       "version": "3.0.0",
       "from": "test-value@https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz"
+    },
+    "tree-kill": {
+      "version": "1.2.0",
+      "from": "tree-kill@latest",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz"
     },
     "typical": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qdone",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "Language agnostic job queue for SQS",
   "main": "index.js",
   "dependencies": {
@@ -11,6 +11,7 @@
     "command-line-usage": "^5.0.3",
     "debug": "^3.1.0",
     "q": "^1.5.1",
+    "tree-kill": "^1.2.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/test/fixtures/test-child-kill-linux.sh
+++ b/test/fixtures/test-child-kill-linux.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+OUTFILE=/tmp/qdone-test-child-kill-linux.out
+rm $OUTFILE
+_term() { 
+  echo "terminated" > $OUTFILE
+  exit 1
+}
+trap _term SIGTERM
+for i in 1 2 3; do sleep 1; echo $i; echo $i >> $OUTFILE; done


### PR DESCRIPTION
Looks like node's `child_process.exec` timeout option only kills the immediate shell and not the shell's children. This PR uses [`tree-kill`](https://www.npmjs.com/package/tree-kill) to ensure the entire tree is dead when qdone says it should be.