### PR TITLE
Add --delay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Options
     -f, --fifo                Create new queues as FIFOs
     -g, --group-id string     FIFO Group ID to use for all messages enqueued in current command. Defaults to an string unique to this invocation.
     --group-id-per-message    Use a unique Group ID for every message, even messages in the same batch.
+    -d, --delay number        Delays delivery of each message by the given number of seconds (up to 900 seconds, or 15 minutes). Defaults to immediate delivery (no delay).
     --prefix string           Prefix to place at the front of each SQS queue name [default: qdone_]
     --fail-suffix string      Suffix to append to each queue to generate fail queue name [default: _failed]
     --region string           AWS region for Queues [default: us-east-1]

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,7 +51,8 @@ function setupVerbose (options) {
 const enqueueOptionDefinitions = [
   { name: 'fifo', alias: 'f', type: Boolean, description: 'Create new queues as FIFOs' },
   { name: 'group-id', alias: 'g', type: String, defaultValue: uuid.v1(), description: 'FIFO Group ID to use for all messages enqueued in current command. Defaults to an string unique to this invocation.' },
-  { name: 'group-id-per-message', type: Boolean, description: 'Use a unique Group ID for every message, even messages in the same batch.' }
+  { name: 'group-id-per-message', type: Boolean, description: 'Use a unique Group ID for every message, even messages in the same batch.' },
+  { name: 'delay', alias: 'd', type: Number, defaultValue: 0, description: 'Delays delivery of each message by the given number of seconds (up to 900 seconds, or 15 minutes). Defaults to immediate delivery (no delay).' }
 ]
 
 exports.enqueue = function enqueue (argv) {


### PR DESCRIPTION
SQS provides a feature where message delivery can be delayed up to 15 minutes (900 seconds) per message.

This PR adds the `--delay <seconds>` option to `enqueue` and `enqueue-batch`. This activates the SQS Message Timer feature on each message enqueued while this option is present.