### PR TITLE
Attribute caching option for #41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/node_modules/
-/.nyc_output
+node_modules/
+.nyc_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 
 language: node_js
+services:
+  - redis-server
 node_js:
   - "6"
 cache:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "command-line-commands": "^2.0.1",
     "command-line-usage": "^5.0.5",
     "debug": "^4.1.0",
+    "ioredis": "^4.14.0",
     "q": "^1.5.1",
     "tree-kill": "^1.2.0",
     "uuid": "^3.3.2"

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,63 @@
+
+const Redis = require('ioredis')
+const { URL } = require('url')
+const debug = require('debug')('qdone:cache')
+
+class UsageError extends Error {}
+
+let client
+
+/**
+ * Internal function to setup redis client. Parses URI to figure out
+ * how to connect.
+ */
+function getClient (options) {
+  if (client) {
+    return client
+  } else if (options['cache-uri']) {
+    const url = new URL(options['cache-uri'])
+    const redisOptions = {keyPrefix: options['cache-prefix']}
+    if (url.protocol === 'redis:') {
+      client = new Redis(url.toString(), redisOptions)
+    } else if (url.protocol === 'redis-cluster:') {
+      url.protocol = 'redis:'
+      client = new Redis.Cluster([url.toString()], {redisOptions})
+    } else {
+      throw new UsageError(`Only redis:// or redis-cluster:// URLs are currently supported. Got: ${url.protocol}`)
+    }
+    // setTimeout(resetClient, 10000)
+    return client
+  } else {
+    throw new UsageError('Caching requires the --cache-uri option')
+  }
+}
+
+function resetClient () {
+  debug({client})
+  if (client) client.quit()
+  client = undefined
+}
+
+/**
+ * Returns a promise for the item. Resolves to false if cache is empty, object
+ * if it is found.
+ */
+function getCache (key, options) {
+  const client = getClient(options)
+  return client.get(key).then(result => {
+    return result ? JSON.parse(result) : undefined
+  })
+}
+
+/**
+ * Returns a promise for the status. Encodes object as JSON
+ */
+function setCache (key, value, options) {
+  const client = getClient(options)
+  const encoded = JSON.stringify(value)
+  return client.setex(key, options['cache-ttl-seconds'], encoded)
+}
+
+module.exports = { getCache, setCache, getClient, resetClient }
+
+debug('loaded')

--- a/src/worker.js
+++ b/src/worker.js
@@ -193,7 +193,7 @@ exports.listen = function listen (queues, options) {
         debug({ entiresBeforeCheck: entries })
         return Promise.all(entries.map(entry =>
           cheapIdleCheck(entry.qname, entry.qrl, options)
-            .then(result =>
+            .then(({result}) =>
               Promise.resolve(
                 Object.assign(entry, { idle: result.idle })
               )

--- a/test/test.cache.js
+++ b/test/test.cache.js
@@ -5,6 +5,7 @@ const cache = require('../src/cache')
 const expect = chai.expect
 
 beforeEach(function () { cache.resetClient() })
+after(function () { cache.resetClient() })
 
 describe('cache', function () {
   const options = {
@@ -15,28 +16,21 @@ describe('cache', function () {
 
   describe('getClient', function () {
     it('should throw an error for invalid cache uri', function () {
-      try {
-        cache.getClient(Object.assign({}, options, {'cache-uri': 'bob://foo'}))
-      } catch (e) {
-        expect(e).to.be.an.Error // eslint-disable-line
-      }
+      const badOptions = Object.assign({}, options, {'cache-uri': 'bob://foo'})
+      expect(() => cache.getClient(badOptions)).to.throw(/currently supported/)
     })
     it('should throw an error when --cache-uri is missing', function () {
-      try {
-        const badOptions = Object.assign({}, options)
-        delete badOptions['cache-uri']
-        cache.getClient(badOptions)
-      } catch (e) {
-        expect(e).to.be.an.Error // eslint-disable-line
-      }
+      const badOptions = Object.assign({}, options)
+      delete badOptions['cache-uri']
+      expect(() => cache.getClient(badOptions)).to.throw(/--cache-uri/)
     })
     it('should support redis:// URIs', function () {
       const client = cache.getClient(options)
-      return expect(client).to.be.defined
+      return expect(client).to.be.ok
     })
     it('should support redis-cache:// URIs', function () {
       const client = cache.getClient(Object.assign({}, options, {'cache-uri': 'redis-cluster://'}))
-      return expect(client).to.be.defined
+      return expect(client).to.be.ok
     })
     it('should return an identical client on subsequent calls', function () {
       const client1 = cache.getClient(options)

--- a/test/test.cache.js
+++ b/test/test.cache.js
@@ -1,0 +1,67 @@
+/* eslint-env mocha */
+
+const chai = require('chai')
+const cache = require('../src/cache')
+const expect = chai.expect
+
+beforeEach(function () { cache.resetClient() })
+
+describe('cache', function () {
+  const options = {
+    'cache-uri': 'redis://localhost',
+    'cache-ttl-seconds': 10,
+    'cache-prefix': 'qdone:'
+  }
+
+  describe('getClient', function () {
+    it('should throw an error for invalid cache uri', function () {
+      try {
+        cache.getClient(Object.assign({}, options, {'cache-uri': 'bob://foo'}))
+      } catch (e) {
+        expect(e).to.be.an.Error // eslint-disable-line
+      }
+    })
+    it('should throw an error when --cache-uri is missing', function () {
+      try {
+        const badOptions = Object.assign({}, options)
+        delete badOptions['cache-uri']
+        cache.getClient(badOptions)
+      } catch (e) {
+        expect(e).to.be.an.Error // eslint-disable-line
+      }
+    })
+    it('should support redis:// URIs', function () {
+      const client = cache.getClient(options)
+      return expect(client).to.be.defined
+    })
+    it('should support redis-cache:// URIs', function () {
+      const client = cache.getClient(Object.assign({}, options, {'cache-uri': 'redis-cluster://'}))
+      return expect(client).to.be.defined
+    })
+    it('should return an identical client on subsequent calls', function () {
+      const client1 = cache.getClient(options)
+      const client2 = cache.getClient(options)
+      return expect(client1).to.be.equal(client2)
+    })
+  })
+
+  describe('setCache', function () {
+    it('should successfully set a value', function () {
+      return cache.setCache('test', {one: 1}, options)
+        .then(result => expect(result).to.equal('OK'))
+    })
+  })
+
+  describe('getCache', function () {
+    it('should return the same value', function () {
+      return cache.getCache('test', options).then(
+        result => expect(JSON.stringify(result)).to.equal(JSON.stringify({one: 1}))
+      )
+    })
+    it('should return undefined for nonexistent keys', function () {
+      return cache.getCache('supercalafragalisticexpealadocious', options).then(
+        result => expect(result).to.be.undefined
+      )
+    })
+  })
+})

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -15,8 +15,8 @@ chai.should()
 delete process.env.AWS_ACCESS_KEY_ID
 delete process.env.AWS_SECRET_ACCESS_KEY
 
-var sandbox
-var clock
+let sandbox
+let clock
 
 beforeEach(function () {
   sandbox = sinon.sandbox.create()
@@ -860,7 +860,6 @@ describe('cli', function () {
         callback(null, {})
       })
     })
-    console.log('what')
     it('should execute the job successfully and exit 0',
       cliTest(['worker', 'test', '--drain', '--kill-after', '1', '--wait-time', '1'], function (result, stdout, stderr) {
         expect(stderr).to.contain('FAILED')
@@ -1150,6 +1149,31 @@ describe('cli', function () {
     })
     it('should make no CloudWatch calls, print nothing to stdout and exit 0',
       cliTest(['idle-queues', 'test', '--unpair'], function (result, stdout, stderr) {
+        expect(stderr).to.contain('Queue test has been active in the last 60 minutes.')
+        expect(stdout).to.equal('')
+      }))
+  })
+
+  describe('qdone idle-queues test --cache-uri redis://localhost # (cached getQueueAttributes call)', function () {
+    before(function () {
+      AWS.mock('SQS', 'getQueueUrl', function (params, callback) {
+        callback(null, { QueueUrl: `https://q.amazonaws.com/123456789101/${params.QueueName}` })
+      })
+      AWS.mock('SQS', 'listQueues', function (params, callback) {
+        callback(null, { QueueUrls: [`https://q.amazonaws.com/123456789101/${params.QueueName}`] })
+      })
+      AWS.mock('SQS', 'getQueueAttributes', function (params, callback) {
+        callback(null, {
+          Attributes: {
+            ApproximateNumberOfMessages: '1',
+            ApproximateNumberOfMessagesDelayed: '0',
+            ApproximateNumberOfMessagesNotVisible: '0'
+          }
+        })
+      })
+    })
+    it('should make one call to getQueueAttributes, print nothing to stdout and exit 0',
+      cliTest(['idle-queues', 'test', '--cache-uri', 'redis://localhost'], function (result, stdout, stderr) {
         expect(stderr).to.contain('Queue test has been active in the last 60 minutes.')
         expect(stdout).to.equal('')
       }))


### PR DESCRIPTION
This PR implements the proposal from #41, adding the following options:

- `--cache-url` that takes a `redis://...` cluster url [no default]
- `--cache-ttl-seconds` that takes a number of seconds [default 10]
- `--cache-prefix` that defines a cache key prefix [default qdone]

The presence of the `--cache-url` option will cause the worker to cache `GetQueueAttributes` for each queue for the specified ttl. Probably can use `mget` for this, if we're careful about key slots.

Supported cache types are `redis://` and `redis-cluster://`
