### PR TITLE
Add deduplication option

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "command-line-usage": "^7.0.1",
     "debug": "^4.3.4",
     "ioredis": "^5.3.2",
+    "ioredis-mock": "^8.9.0",
     "standard": "^17.1.0",
     "tree-kill": "^1.2.2",
     "uuid": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build": "tsc --allowJs index.js --outdir commonjs --esModuleInterop --module commonjs  --target es2021 --strict --skipLibCheck --forceConsistentCasingInFileNames",
     "clean": "rm -rf commonjs/src commonjs/*.js coverage",
     "lint": "standard",
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "coverage": "NODE_OPTIONS='--experimental-json-modules --experimental-vm-modules --no-warnings' jest --coverage | coveralls",
     "standard": "standard",
     "prep-for-publish": "echo YOU MUST USE NPM TO PREP FOR PUBLISH && pnpm run clean && pnpm run build && npm shrinkwrap --production && echo now commit shrinkwrap and use npm run publish-{next,latest}",
     "publish-latest": "npm publish --tag latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ dependencies:
   ioredis:
     specifier: ^5.3.2
     version: 5.3.2
+  ioredis-mock:
+    specifier: ^8.9.0
+    version: 8.9.0(@types/ioredis-mock@8.2.5)(ioredis@5.3.2)
   standard:
     specifier: ^17.1.0
     version: 17.1.0
@@ -986,6 +989,10 @@ packages:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
     dev: false
 
+  /@ioredis/as-callback@3.0.0:
+    resolution: {integrity: sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==}
+    dev: false
+
   /@ioredis/commands@1.2.0:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
     dev: false
@@ -1829,6 +1836,15 @@ packages:
       '@types/node': 20.10.3
     dev: true
 
+  /@types/ioredis-mock@8.2.5:
+    resolution: {integrity: sha512-cZyuwC9LGtg7s5G9/w6rpy3IOZ6F/hFR0pQlWYZESMo1xQUYbDpa6haqB4grTePjsGzcB/YLBFCjqRunK5wieg==}
+    dependencies:
+      '@types/node': 20.10.3
+      ioredis: 5.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@types/istanbul-lib-coverage@2.0.6:
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
     dev: true
@@ -1860,7 +1876,6 @@ packages:
     resolution: {integrity: sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
 
   /@types/sinon@10.0.20:
     resolution: {integrity: sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==}
@@ -2950,6 +2965,22 @@ packages:
       bser: 2.1.1
     dev: true
 
+  /fengari-interop@0.1.3(fengari@0.1.4):
+    resolution: {integrity: sha512-EtZ+oTu3kEwVJnoymFPBVLIbQcCoy9uWCVnMA6h3M/RqHkUBsLYp29+RRHf9rKr6GwjubWREU1O7RretFIXjHw==}
+    peerDependencies:
+      fengari: ^0.1.0
+    dependencies:
+      fengari: 0.1.4
+    dev: false
+
+  /fengari@0.1.4:
+    resolution: {integrity: sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==}
+    dependencies:
+      readline-sync: 1.4.10
+      sprintf-js: 1.1.3
+      tmp: 0.0.33
+    dev: false
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3235,6 +3266,22 @@ packages:
       get-intrinsic: 1.2.2
       hasown: 2.0.0
       side-channel: 1.0.4
+    dev: false
+
+  /ioredis-mock@8.9.0(@types/ioredis-mock@8.2.5)(ioredis@5.3.2):
+    resolution: {integrity: sha512-yIglcCkI1lvhwJVoMsR51fotZVsPsSk07ecTCgRTRlicG0Vq3lke6aAaHklyjmRNRsdYAgswqC2A0bPtQK4LSw==}
+    engines: {node: '>=12.22'}
+    peerDependencies:
+      '@types/ioredis-mock': ^8
+      ioredis: ^5
+    dependencies:
+      '@ioredis/as-callback': 3.0.0
+      '@ioredis/commands': 1.2.0
+      '@types/ioredis-mock': 8.2.5
+      fengari: 0.1.4
+      fengari-interop: 0.1.3(fengari@0.1.4)
+      ioredis: 5.3.2
+      semver: 7.5.4
     dev: false
 
   /ioredis@5.3.2:
@@ -4308,6 +4355,11 @@ packages:
       type-check: 0.4.0
     dev: false
 
+  /os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -4490,6 +4542,11 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
+
+  /readline-sync@1.4.10:
+    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
+    engines: {node: '>= 0.8.0'}
+    dev: false
 
   /redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -4698,6 +4755,10 @@ packages:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
 
+  /sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+    dev: false
+
   /stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -4881,6 +4942,13 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: false
 
+  /tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      os-tmpdir: 1.0.2
+    dev: false
+
   /tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
     dev: true
@@ -5010,7 +5078,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
 
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}

--- a/src/cache.js
+++ b/src/cache.js
@@ -12,15 +12,16 @@ let client
  * how to connect.
  */
 export function getCacheClient (opt) {
+  const RedisClass = opt.Redis || Redis
   if (client) {
     return client
   } else if (opt.cacheUri) {
     const url = new URL(opt.cacheUri)
     if (url.protocol === 'redis:') {
-      client = new Redis(url.toString())
+      client = new RedisClass(url.toString())
     } else if (url.protocol === 'redis-cluster:') {
       url.protocol = 'redis:'
-      client = new Redis.Cluster([url.toString()], { slotsRefreshInterval: 60 * 1000 })
+      client = new RedisClass.Cluster([url.toString()], { slotsRefreshInterval: 60 * 1000 })
     } else {
       throw new UsageError(`Only redis:// or redis-cluster:// URLs are currently supported. Got: ${url.protocol}`)
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -42,6 +42,8 @@ const globalOptionDefinitions = [
   { name: 'cache-prefix', type: String, description: `Prefix for all keys in cache. [default: ${defaults.cachePrefix}]` },
   { name: 'cache-ttl-seconds', type: Number, description: `Number of seconds to cache GetQueueAttributes calls. [default: ${defaults.cacheTtlSeconds}]` },
   { name: 'help', type: Boolean, description: 'Print full help message.' },
+  { name: 'external-dedup', type: Boolean, description: 'Moves deduplication from SQS to qdone external cache, allowing a longer deduplication window and alternate semantics.' },
+  { name: 'dedup-period', type: Number, description: 'Number of seconds (counting from the first enqueue) to prevent a duplicate message from being sent. Resets after a message with that deduplication id has been successfully processed. Minumum 360 seconds.' },
   { name: 'sentry-dsn', type: String, description: 'Optional Sentry DSN to track unhandled errors.' }
 ]
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -44,6 +44,7 @@ const globalOptionDefinitions = [
   { name: 'help', type: Boolean, description: 'Print full help message.' },
   { name: 'external-dedup', type: Boolean, description: 'Moves deduplication from SQS to qdone external cache, allowing a longer deduplication window and alternate semantics.' },
   { name: 'dedup-period', type: Number, description: 'Number of seconds (counting from the first enqueue) to prevent a duplicate message from being sent. Resets after a message with that deduplication id has been successfully processed. Minumum 360 seconds.' },
+  { name: 'dedup-stats', type: Boolean, description: 'Keeps statistics on dedup keys. Disabled by default. Increases load on redis.' },
   { name: 'sentry-dsn', type: String, description: 'Optional Sentry DSN to track unhandled errors.' }
 ]
 

--- a/src/dedup.js
+++ b/src/dedup.js
@@ -1,0 +1,77 @@
+import { getCacheClient } from './cache.js'
+import Debug from 'debug'
+const debug = Debug('qdone:dedup')
+
+export function getCacheKey (content, opt) {
+  const cacheKey = opt.cachePrefix + 'dedup:' + content.trim()
+  debug({ action: 'shouldEnqueue', cacheKey })
+  return cacheKey
+}
+export async function dedupShouldEnqueue (content, opt) {
+  if (opt.dedupMethod === 'redis') {
+    const client = getCacheClient(opt)
+    const cacheKey = getCacheKey(content, opt)
+    const result = await client.incr(cacheKey)
+    debug({ action: 'shouldEnqueue', cacheKey, result })
+    if (result === 1) {
+      // We won, now make sure it expires
+      await client.expire(cacheKey, opt.dedupPeriod)
+      return true
+    }
+    return false
+  } else {
+    return true
+  }
+}
+
+export async function dedupShouldEnqueueMulti (contentArray, opt) {
+  const results = {}
+  if (opt.dedupMethod === 'redis') {
+    // Increment all
+    const incrPipeline = getCacheClient().pipeline()
+    for (const content of contentArray) {
+      const cacheKey = getCacheKey(content, opt)
+      incrPipeline.incr(cacheKey)
+    }
+    const responses = await incrPipeline.exec()
+
+    // Interpret responses and expire keys for races we won
+    const expirePipeline = getCacheClient().pipeline()
+    for (let i = 0; i < contentArray.length; i++) {
+      const content = contentArray[i]
+      const response = responses[i]
+      const cacheKey = getCacheKey(content, opt)
+      if (response === 1) {
+        results[content] = true
+        expirePipeline.expire(cacheKey, opt.dedupPeriod)
+      } else {
+        results[content] = false
+      }
+    }
+    await await expirePipeline.exec()
+  } else {
+    // If we're not using redis, send everything
+    for (const content of contentArray) results[content] = true
+  }
+  return results
+}
+
+export async function dedupSuccessfullyProcessed (content, opt) {
+  if (opt.dedupMethod === 'redis') {
+    const client = getCacheClient(opt)
+    const cacheKey = opt.cachePrefix + ':dedup:' + content.trim()
+    debug({ action: 'shouldProcess', cacheKey })
+    await client.del(cacheKey)
+  }
+}
+
+export async function dedupSuccessfullyProcessedMulti (contentArray, opt) {
+  if (opt.dedupMethod === 'redis') {
+    const delPipeline = getCacheClient().pipeline()
+    for (const content of contentArray) {
+      const cacheKey = getCacheKey(content, opt)
+      delPipeline.del(cacheKey)
+    }
+    await delPipeline.exec()
+  }
+}

--- a/src/dedup.js
+++ b/src/dedup.js
@@ -1,16 +1,40 @@
+import { createHash } from 'crypto'
 import { getCacheClient } from './cache.js'
 import Debug from 'debug'
 const debug = Debug('qdone:dedup')
 
-export function getCacheKey (content, opt) {
-  const cacheKey = opt.cachePrefix + 'dedup:' + content.trim()
+/**
+ * This function returns the cache key for deduplication checks for the given
+ * message. If the message has a MessageDeduplicationId, that is used,
+ * otherwise the MessageBody is used.
+ * @param message - Parameters to SendMessageCommand
+ * @param opt - Opt object from getOptionsWithDefaults()
+ * @returns the cache key
+ */
+export function getCacheKey (message, opt) {
+  let dedupContent = message?.MessageDeduplicationId || message?.MessageAttributes?.DeduplicationId?.StringValue || message?.MessageBody || message?.Body
+  // Don't transmit long keys to redis
+  const max = 256
+  const sep = '...sha1:'
+  if (dedupContent.length > max) {
+    dedupContent = dedupContent.slice(0, max - sep.length - 40) + '...sha1:' + createHash('sha1').update(dedupContent).digest('hex')
+  }
+  const cacheKey = opt.cachePrefix + 'dedup:' + dedupContent.trim()
   debug({ action: 'shouldEnqueue', cacheKey })
   return cacheKey
 }
-export async function dedupShouldEnqueue (content, opt) {
+
+/**
+ * Determines whether we should enqueue this message or whether it is a duplicate.
+ * Returns true if enqueuing the message would not result in a duplicate.
+ * @param message - Parameters to SendMessageCommand
+ * @param opt - Opt object from getOptionsWithDefaults()
+ * @returns true if the message can be enqueued without duplicate, else false
+ */
+export async function dedupShouldEnqueue (message, opt) {
   if (opt.dedupMethod === 'redis') {
     const client = getCacheClient(opt)
-    const cacheKey = getCacheKey(content, opt)
+    const cacheKey = getCacheKey(message, opt)
     const result = await client.incr(cacheKey)
     debug({ action: 'shouldEnqueue', cacheKey, result })
     if (result === 1) {
@@ -24,54 +48,81 @@ export async function dedupShouldEnqueue (content, opt) {
   }
 }
 
-export async function dedupShouldEnqueueMulti (contentArray, opt) {
-  const results = {}
+/**
+ * Determines which messages we should enqueue, returning only those that
+ * would not be duplicates. 
+ * @param messages - params.Entries for the SendMessageBatchCommand
+ * @param opt - Opt object from getOptionsWithDefaults()
+ * @returns an array of messages that can be safely enqueued. Could be empty.
+ */
+export async function dedupShouldEnqueueMulti (messages, opt) {
+  debug({ dedupShouldEnqueueMulti: { messages, opt }})
   if (opt.dedupMethod === 'redis') {
     // Increment all
-    const incrPipeline = getCacheClient().pipeline()
-    for (const content of contentArray) {
-      const cacheKey = getCacheKey(content, opt)
+    const incrPipeline = getCacheClient(opt).pipeline()
+    for (const message of messages) {
+      const cacheKey = getCacheKey(message, opt)
       incrPipeline.incr(cacheKey)
     }
     const responses = await incrPipeline.exec()
+    debug({ dedupShouldEnqueueMulti: responses })
 
     // Interpret responses and expire keys for races we won
-    const expirePipeline = getCacheClient().pipeline()
-    for (let i = 0; i < contentArray.length; i++) {
-      const content = contentArray[i]
-      const response = responses[i]
-      const cacheKey = getCacheKey(content, opt)
+    const expirePipeline = getCacheClient(opt).pipeline()
+    const messagesToEnqueue = []
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i]
+      const [, response] = responses[i]
+      const cacheKey = getCacheKey(message, opt)
       if (response === 1) {
-        results[content] = true
+        messagesToEnqueue.push(message)
         expirePipeline.expire(cacheKey, opt.dedupPeriod)
-      } else {
-        results[content] = false
       }
     }
-    await await expirePipeline.exec()
+    await expirePipeline.exec()
+    return messagesToEnqueue
   } else {
     // If we're not using redis, send everything
-    for (const content of contentArray) results[content] = true
+    return messages
   }
-  return results
 }
 
-export async function dedupSuccessfullyProcessed (content, opt) {
+/**
+ * Marks a message as processed so that subsequent calls to dedupShouldEnqueue
+ * and dedupShouldEnqueueMulti will allow a message to be enqueued again
+ * wihtout waiting for dedupPeriod to expire.
+ * @param message - Return value from RecieveMessageCommand
+ * @param opt - Opt object from getOptionsWithDefaults()
+ * @returns 1 if a cache key was deleted, otherwise 0
+ */
+export async function dedupSuccessfullyProcessed (message, opt) {
   if (opt.dedupMethod === 'redis') {
     const client = getCacheClient(opt)
-    const cacheKey = opt.cachePrefix + ':dedup:' + content.trim()
+    const cacheKey = getCacheKey(message, opt)
     debug({ action: 'shouldProcess', cacheKey })
-    await client.del(cacheKey)
+    return client.del(cacheKey)
   }
+  return 0
 }
 
-export async function dedupSuccessfullyProcessedMulti (contentArray, opt) {
+/**
+ * Marks a message as processed so that subsequent calls to dedupShouldEnqueue
+ * and dedupShouldEnqueueMulti will allow a message to be enqueued again
+ * wihtout waiting for dedupPeriod to expire.
+ * @param messages - Array of return values from RecieveMessageCommand
+ * @param opt - Opt object from getOptionsWithDefaults()
+ * @returns the number of cache keys deleted
+ */
+export async function dedupSuccessfullyProcessedMulti (messages, opt) {
   if (opt.dedupMethod === 'redis') {
-    const delPipeline = getCacheClient().pipeline()
-    for (const content of contentArray) {
-      const cacheKey = getCacheKey(content, opt)
+    const delPipeline = getCacheClient(opt).pipeline()
+    for (const message of messages) {
+      const cacheKey = getCacheKey(message, opt)
+      debug({ dedupSuccessfullyProcessedMulti: { cacheKey } })
       delPipeline.del(cacheKey)
     }
-    await delPipeline.exec()
+    const results = await delPipeline.exec()
+    return results.map(([, val]) => val).reduce((a, b) => a + b, 0)
   }
+  return 0
 }

--- a/src/dedup.js
+++ b/src/dedup.js
@@ -1,128 +1,211 @@
 import { createHash } from 'crypto'
+import { v1 as uuidV1 } from 'uuid'
 import { getCacheClient } from './cache.js'
 import Debug from 'debug'
 const debug = Debug('qdone:dedup')
 
 /**
- * This function returns the cache key for deduplication checks for the given
- * message. If the message has a MessageDeduplicationId, that is used,
- * otherwise the MessageBody is used.
- * @param message - Parameters to SendMessageCommand
- * @param opt - Opt object from getOptionsWithDefaults()
- * @returns the cache key
+ * Returns a MessageDeduplicationId key appropriate for using with Amazon SQS
+ * for the given message. The passed dedupContent will be returned untouched
+ * if it meets all the requirements for SQS's MessageDeduplicationId,
+ * otherwise disallowed characters will be replaced by `_` and content longer
+ * than 128 characters will be truncated and a hash of the content appended.
+ * @param {String} dedupContent - Content used to construct the deduplication id.
+ * @param {Object} opt - Opt object from getOptionsWithDefaults()
+ * @returns {String} the cache key
  */
-export function getCacheKey (message, opt) {
-  let dedupContent = message?.MessageDeduplicationId || message?.MessageAttributes?.DeduplicationId?.StringValue || message?.MessageBody || message?.Body
+export function getDeduplicationId (dedupContent, opt) {
+  debug({ getDeduplicationId: { dedupContent } })
   // Don't transmit long keys to redis
-  const max = 256
+  dedupContent = dedupContent.trim().replace(/[^a-zA-Z0-9!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]/g, '_')
+  const max = 128
   const sep = '...sha1:'
   if (dedupContent.length > max) {
     dedupContent = dedupContent.slice(0, max - sep.length - 40) + '...sha1:' + createHash('sha1').update(dedupContent).digest('hex')
   }
-  const cacheKey = opt.cachePrefix + 'dedup:' + dedupContent.trim()
-  debug({ action: 'shouldEnqueue', cacheKey })
+  return dedupContent
+}
+
+/**
+ * Returns the cache key given a deduplication id.
+ * @param {String} dedupId - a deduplication id returned from getDeduplicationId
+ * @param opt - Opt object from getOptionsWithDefaults()
+ * @returns the cache key
+ */
+export function getCacheKey (dedupId, opt) {
+  const cacheKey = opt.cachePrefix + 'dedup:' + dedupId
+  debug({ getCacheKey: { cacheKey } })
   return cacheKey
+}
+
+/**
+ * Modifies a message (parameters to SendMessageCommand) to add the parameters
+ * for whatever deduplication options the caller has set.
+ * @param {String} message - parameters to SendMessageCommand
+ * @param {Object} opt - Opt object from getOptionsWithDefaults()
+ * @returns {Object} the modified parameters/message object
+ */
+export function addDedupParamsToMessage (message, opt) {
+  if (opt.fifo) {
+    const uuidFunction = opt.uuidFunction || uuidV1
+    if (opt.deduplicationId) message.MessageDeduplicationId = opt.deduplicationId
+    if (opt.dedupIdPerMessage) message.MessageDeduplicationId = uuidFunction()
+
+    // Fallback to using the message body
+    if (!message.MessageDeduplicationId) {
+      message.MessageDeduplicationId = getDeduplicationId(message.MessageBody, opt)
+    }
+
+    // Track this so we can see it on the receiving end
+    if (opt.externalDedup) {
+      message.MessageAttributes = {
+        QdoneDeduplicationId: {
+          StringValue: message.MessageDeduplicationId,
+          DataType: 'String'
+        }
+      }
+    }
+  }
+  return message
+}
+
+/**
+ * Calculates:
+ *  - dedupPeriod: the number of seconds from now until another duplicate is
+ *    allowed to run (if the current running duplicate does not finish earlier)
+ *  - canExpireAfter: the earliest absolute timestamp when another duplicate
+ *    job can run provided the running job completes. This value is used by
+ *    dedupSuccessfullyProcessed and dedupSuccessfullyProcessedMulti to either
+ *    expire a the key or schedule it's expiration if a job finishes
+ */
+export function calculateDedupParams (opt) {
+  // We won, now make sure it expires
+  const minDedupPeriod = 6 * 60
+  const dedupPeriod = Math.max(opt.dedupPeriod, minDedupPeriod) // at least minDedupPeriod
+  const timestamp = new Date().getTime()
+  // Wait at least the minDedupPeriod before we are allowed to expire
+  const canExpireAfter = Math.round(timestamp / 1000.0 + minDedupPeriod)
+  debug({ calculateDedupParams: { minDedupPeriod, dedupPeriod, timestamp, canExpireAfter }})
+  return { minDedupPeriod, dedupPeriod, timestamp, canExpireAfter }
 }
 
 /**
  * Determines whether we should enqueue this message or whether it is a duplicate.
  * Returns true if enqueuing the message would not result in a duplicate.
- * @param message - Parameters to SendMessageCommand
- * @param opt - Opt object from getOptionsWithDefaults()
- * @returns true if the message can be enqueued without duplicate, else false
+ * @param {Object} message - Parameters to SendMessageCommand
+ * @param {Object} opt - Opt object from getOptionsWithDefaults()
+ * @returns {Boolean} true if the message can be enqueued without duplicate, else false
  */
 export async function dedupShouldEnqueue (message, opt) {
-  if (opt.dedupMethod === 'redis') {
-    const client = getCacheClient(opt)
-    const cacheKey = getCacheKey(message, opt)
-    const result = await client.incr(cacheKey)
-    debug({ action: 'shouldEnqueue', cacheKey, result })
-    if (result === 1) {
-      // We won, now make sure it expires
-      await client.expire(cacheKey, opt.dedupPeriod)
-      return true
-    }
-    return false
-  } else {
+  const client = getCacheClient(opt)
+  const dedupId = message?.MessageAttributes?.QdoneDeduplicationId?.StringValue
+  const cacheKey = getCacheKey(dedupId, opt)
+  const result = await client.incr(cacheKey)
+  debug({ action: 'shouldEnqueue', cacheKey, result })
+  if (result === 1) {
+    const { canExpireAfter, dedupPeriod } = calculateDedupParams(opt)
+    await client.set(cacheKey, canExpireAfter, 'EX', dedupPeriod)
     return true
   }
+  return false
 }
 
 /**
  * Determines which messages we should enqueue, returning only those that
- * would not be duplicates. 
- * @param messages - params.Entries for the SendMessageBatchCommand
- * @param opt - Opt object from getOptionsWithDefaults()
- * @returns an array of messages that can be safely enqueued. Could be empty.
+ * would not be duplicates.
+ * @param {Array[Object]} messages - Entries array for the SendMessageBatchCommand
+ * @param {Object} opt - Opt object from getOptionsWithDefaults()
+ * @returns {Array[Object]} an array of messages that can be safely enqueued. Could be empty.
  */
 export async function dedupShouldEnqueueMulti (messages, opt) {
   debug({ dedupShouldEnqueueMulti: { messages, opt }})
-  if (opt.dedupMethod === 'redis') {
-    // Increment all
-    const incrPipeline = getCacheClient(opt).pipeline()
-    for (const message of messages) {
-      const cacheKey = getCacheKey(message, opt)
-      incrPipeline.incr(cacheKey)
-    }
-    const responses = await incrPipeline.exec()
-    debug({ dedupShouldEnqueueMulti: responses })
-
-    // Interpret responses and expire keys for races we won
-    const expirePipeline = getCacheClient(opt).pipeline()
-    const messagesToEnqueue = []
-    for (let i = 0; i < messages.length; i++) {
-      const message = messages[i]
-      const [, response] = responses[i]
-      const cacheKey = getCacheKey(message, opt)
-      if (response === 1) {
-        messagesToEnqueue.push(message)
-        expirePipeline.expire(cacheKey, opt.dedupPeriod)
-      }
-    }
-    await expirePipeline.exec()
-    return messagesToEnqueue
-  } else {
-    // If we're not using redis, send everything
-    return messages
+  // Increment all
+  const incrPipeline = getCacheClient(opt).pipeline()
+  for (const message of messages) {
+    const dedupId = message?.MessageAttributes?.QdoneDeduplicationId?.StringValue
+    const cacheKey = getCacheKey(dedupId, opt)
+    incrPipeline.incr(cacheKey)
   }
+  const responses = await incrPipeline.exec()
+  debug({ dedupShouldEnqueueMulti: { messages, responses } })
+
+  // Figure out dedup period
+  const minDedupPeriod = 6 * 60
+  const dedupPeriod = Math.min(opt.dedupPeriod, minDedupPeriod)
+
+  // Interpret responses and expire keys for races we won
+  const expirePipeline = getCacheClient(opt).pipeline()
+  const messagesToEnqueue = []
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+    const [, response] = responses[i]
+    const dedupId = message?.MessageAttributes?.QdoneDeduplicationId?.StringValue
+    const cacheKey = getCacheKey(dedupId, opt)
+    if (response === 1) {
+      messagesToEnqueue.push(message)
+      const { canExpireAfter, dedupPeriod } = calculateDedupParams(opt)
+      expirePipeline.set(cacheKey, canExpireAfter, 'EX', dedupPeriod)
+    }
+  }
+  await expirePipeline.exec()
+  return messagesToEnqueue
 }
 
 /**
  * Marks a message as processed so that subsequent calls to dedupShouldEnqueue
  * and dedupShouldEnqueueMulti will allow a message to be enqueued again
- * wihtout waiting for dedupPeriod to expire.
- * @param message - Return value from RecieveMessageCommand
- * @param opt - Opt object from getOptionsWithDefaults()
- * @returns 1 if a cache key was deleted, otherwise 0
+ * without waiting for dedupPeriod to expire.
+ * @param {Object} message - Return value from RecieveMessageCommand
+ * @param {Object} opt - Opt object from getOptionsWithDefaults()
+ * @returns {Number} 1 if a cache key was deleted, otherwise 0
  */
 export async function dedupSuccessfullyProcessed (message, opt) {
-  if (opt.dedupMethod === 'redis') {
-    const client = getCacheClient(opt)
-    const cacheKey = getCacheKey(message, opt)
-    debug({ action: 'shouldProcess', cacheKey })
-    return client.del(cacheKey)
+  const client = getCacheClient(opt)
+  const dedupId = message?.MessageAttributes?.QdoneDeduplicationId?.StringValue
+  if (dedupId) {
+    // Instead of just deleting the key here, we need to make sure that we
+    // wait at least as long as SQS's dedup period. This is because we may
+    // get a successful call to enqueue a message that doesn't really send
+    // the message because of SQS's own dedup. This can cause us to
+    // accidentally refuse to enqueue a message in the following situation:
+    //   1) Send a message. We check the dedup id and give the OK
+    //   2) SQS gets the message, they track dedup id for 5 minutes
+    //   3) We process message and delete it within the 5 minutes
+    //   4) We also delete our record, allowing future duplicates
+    //   5) We enqueue another duplicate, our record allows it
+    //   6) We send to SQS and get a success, but SQS has silently dropped
+    //      because we are still in the 5 minute window
+    //   7) Now there is no message in flight to trigger deleting this key
+    //      and there won't be until the end of the dedup period
+    // So, the upshot is that we have to wait at least as long as SQS
+    const cacheKey = getCacheKey(dedupId, opt)
+    const canExpireAfter = parseInt(await client.get(cacheKey))
+    // If canExpireAfter is in the past, this call will delete the key
+    // otherwise it will delete as soon as the min dedup period is up
+    debug({ dedupSuccessfullyProcessed: { dedupId, cacheKey, canExpireAfter } })
+    // Note that if the key has already expired, we need do nothing
+    if (canExpireAfter > 0) {
+      const result = await client.expireat(cacheKey, canExpireAfter)
+      debug({ dedupSuccessfullyProcessed: { dedupId, cacheKey, result } })
+    }
   }
-  return 0
 }
 
 /**
- * Marks a message as processed so that subsequent calls to dedupShouldEnqueue
- * and dedupShouldEnqueueMulti will allow a message to be enqueued again
- * wihtout waiting for dedupPeriod to expire.
- * @param messages - Array of return values from RecieveMessageCommand
- * @param opt - Opt object from getOptionsWithDefaults()
- * @returns the number of cache keys deleted
+ * If we got a non-retryable error from SQS, we need to remove our key so the
+ * application can try again without waiting the entire dedupPeriod.
+ * @param {Object} message - Return value from RecieveMessageCommand
+ * @param {Object} opt - Opt object from getOptionsWithDefaults()
+ * @returns {Number} 1 if a cache key was deleted, otherwise 0
  */
-export async function dedupSuccessfullyProcessedMulti (messages, opt) {
-  if (opt.dedupMethod === 'redis') {
-    const delPipeline = getCacheClient(opt).pipeline()
-    for (const message of messages) {
-      const cacheKey = getCacheKey(message, opt)
-      debug({ dedupSuccessfullyProcessedMulti: { cacheKey } })
-      delPipeline.del(cacheKey)
-    }
-    const results = await delPipeline.exec()
-    return results.map(([, val]) => val).reduce((a, b) => a + b, 0)
+export async function dedupErrorBeforeAcknowledgement (message, opt) {
+  const dedupId = message?.MessageAttributes?.QdoneDeduplicationId?.StringValue
+  if (dedupId) {
+    const client = getCacheClient(opt)
+    const cacheKey = getCacheKey(dedupId, opt)
+    const result = await client.del(cacheKey)
+    debug({ dedupErrorBeforeAcknowledgement: { dedupId, result } })
   }
-  return 0
 }
+
+// TODO: rewrite dedupSuccessfullyProcessed

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -19,7 +19,7 @@ export const defaults = Object.freeze({
   disableLog: false,
   includeFailed: false,
   includeDead: false,
-  dedupMethod: 'sqs',
+  externalDedup: false,
   dedupPeriod: 60 * 5,
 
   // Enqueue
@@ -82,7 +82,7 @@ export function getOptionsWithDefaults (options) {
     disableLog: options.disableLog || options['disable-log'] || defaults.disableLog,
     includeFailed: options.includeFailed || options['include-failed'] || defaults.includeFailed,
     includeDead: options.includeDead || options['include-dead'] || defaults.includeDead,
-    dedupMethod: options.dedupMethod || options['dedup-method'] || defaults.dedupMethod,
+    externalDedup: options.externalDedup || options['external-dedup'] || defaults.externalDedup,
     dedupPeriod: options.dedupPeriod || options['dedup-period'] || defaults.dedupPeriod,
 
     // Cache
@@ -136,14 +136,9 @@ export function getOptionsWithDefaults (options) {
   opt.idleFor = validateInteger(opt, 'idleFor')
 
   // Validate dedup args
-  const dedupMethods = [
-    'sqs',
-    'redis'
-  ]
-  if (!dedupMethods.includes(opt.dedupMethod)) throw new Error('Invalid dedup method')
-  if (opt.dedupMethod === 'redis' && !opt.cacheUri) throw new Error('dedup-method of redis requires a cache-uri')
-  if (opt.dedupMethod === 'redis' && (!opt.dedupPeriod || opt.dedupPeriod < 1)) throw new Error('dedup-method of redis requires a dedup-period > 1 second')
-  if (opt.dedupIdPerMessage && opt.deduplicationId) throw new Error('Use either deduplication-id or dedup-id-per-message but not both')
+  if (opt.externalDedup && !opt.cacheUri) throw new Error('--external-dedup requires the --cache-uri argument')
+  if (opt.externalDedup && (!opt.dedupPeriod || opt.dedupPeriod < 1)) throw new Error('--external-dedup of redis requires a --dedup-period > 1 second')
+  if (opt.dedupIdPerMessage && opt.deduplicationId) throw new Error('Use either --deduplication-id or --dedup-id-per-message but not both')
 
   return opt
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -21,6 +21,7 @@ export const defaults = Object.freeze({
   includeDead: false,
   externalDedup: false,
   dedupPeriod: 60 * 5,
+  dedupStats: false,
 
   // Enqueue
   groupId: uuidv1(),
@@ -84,6 +85,7 @@ export function getOptionsWithDefaults (options) {
     includeDead: options.includeDead || options['include-dead'] || defaults.includeDead,
     externalDedup: options.externalDedup || options['external-dedup'] || defaults.externalDedup,
     dedupPeriod: options.dedupPeriod || options['dedup-period'] || defaults.dedupPeriod,
+    dedupStats: options.dedupStats || options['dedup-stats'] || defaults.dedupStats,
 
     // Cache
     cacheUri: options.cacheUri || options['cache-uri'] || defaults.cacheUri,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -20,12 +20,13 @@ export const defaults = Object.freeze({
   includeFailed: false,
   includeDead: false,
   dedupMethod: 'sqs',
-  dedupPeriod: 60 * 60 * 24,
+  dedupPeriod: 60 * 5,
 
   // Enqueue
   groupId: uuidv1(),
   groupIdPerMessage: false,
   deduplicationId: undefined,
+  dedupIdPerMessage: false,
   messageRetentionPeriod: 1209600,
   delay: 0,
   sendRetries: 6,
@@ -93,6 +94,7 @@ export function getOptionsWithDefaults (options) {
     groupId: options.groupId || options['group-id'] || defaults.groupId,
     groupIdPerMessage: false,
     deduplicationId: options.deduplicationId || options['deduplication-id'] || defaults.deduplicationId,
+    dedupIdPerMessage: options.dedupIdPerMessage || options['dedup-id-per-message'] || defaults.dedupIdPerMessage,
     messageRetentionPeriod: options.messageRetentionPeriod || options['message-retention-period'] || defaults.messageRetentionPeriod,
     delay: options.delay || defaults.delay,
     sendRetries: options['send-retries'] || defaults.sendRetries,
@@ -141,6 +143,7 @@ export function getOptionsWithDefaults (options) {
   if (!dedupMethods.includes(opt.dedupMethod)) throw new Error('Invalid dedup method')
   if (opt.dedupMethod === 'redis' && !opt.cacheUri) throw new Error('dedup-method of redis requires a cache-uri')
   if (opt.dedupMethod === 'redis' && (!opt.dedupPeriod || opt.dedupPeriod < 1)) throw new Error('dedup-method of redis requires a dedup-period > 1 second')
+  if (opt.dedupIdPerMessage && opt.deduplicationId) throw new Error('Use either deduplication-id or dedup-id-per-message but not both')
 
   return opt
 }

--- a/src/enqueue.js
+++ b/src/enqueue.js
@@ -24,7 +24,7 @@ import {
   addDedupParamsToMessage,
   dedupShouldEnqueue,
   dedupShouldEnqueueMulti,
-  dedupErrorBeforeAcknowledgement
+  dedupSuccessfullyProcessed
 } from './dedup.js'
 import { getOptionsWithDefaults } from './defaults.js'
 import { ExponentialBackoff } from './exponentialBackoff.js'
@@ -212,7 +212,7 @@ export async function sendMessage (qrl, command, opt) {
       }
     }
     // If we could not send it, we also need to remove our dedup flag
-    await dedupErrorBeforeAcknowledgement(params, opt)
+    await dedupSuccessfullyProcessed(params, opt)
     return false
   }
   const result = await backoff.run(send, shouldRetry)

--- a/src/scheduler/jobExecutor.js
+++ b/src/scheduler/jobExecutor.js
@@ -224,7 +224,7 @@ export class JobExecutor {
         debug('DeleteMessageBatch returned', result)
 
         // Mark batch as processed for dedup
-        await dedupSuccessfullyProcessedMulti(entries.map(e => this.jobsByMessageId[e.Id].Body), this.opt)
+        await dedupSuccessfullyProcessedMulti(entries.map(e => this.jobsByMessageId[e.Id]), this.opt)
 
         // TODO Sentry
       }

--- a/src/scheduler/jobExecutor.js
+++ b/src/scheduler/jobExecutor.js
@@ -8,6 +8,7 @@ import { ChangeMessageVisibilityBatchCommand, DeleteMessageBatchCommand } from '
 import chalk from 'chalk'
 import Debug from 'debug'
 
+import { dedupSuccessfullyProcessedMulti } from '../dedup.js'
 import { getSQSClient } from '../sqs.js'
 
 const debug = Debug('qdone:jobExecutor')
@@ -221,6 +222,10 @@ export class JobExecutor {
           }
         }
         debug('DeleteMessageBatch returned', result)
+
+        // Mark batch as processed for dedup
+        await dedupSuccessfullyProcessedMulti(entries.map(e => this.jobsByMessageId[e.Id].Body), this.opt)
+
         // TODO Sentry
       }
     }

--- a/src/worker.js
+++ b/src/worker.js
@@ -137,7 +137,7 @@ export async function executeJob (job, qname, qrl, opt) {
     }
 
     // Let dedup system know we processed it
-    await dedupSuccessfullyProcessed(job.Body, opt)
+    await dedupSuccessfullyProcessed(job, opt)
 
     return { noJobs: 0, jobsSucceeded: 1, jobsFailed: 0 }
   } catch (err) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -13,6 +13,7 @@ import treeKill from 'tree-kill'
 import chalk from 'chalk'
 import Debug from 'debug'
 
+import { dedupSuccessfullyProcessed } from './dedup.js'
 import { normalizeQueueName, getQnameUrlPairs } from './qrlCache.js'
 import { getOptionsWithDefaults } from './defaults.js'
 import { cheapIdleCheck } from './idleQueues.js'
@@ -129,10 +130,15 @@ export async function executeJob (job, qname, qrl, opt) {
       QueueUrl: qrl,
       ReceiptHandle: job.ReceiptHandle
     }))
+
     if (opt.verbose) {
       console.error(chalk.blue('  done'))
       console.error()
     }
+
+    // Let dedup system know we processed it
+    await dedupSuccessfullyProcessed(job.Body, opt)
+
     return { noJobs: 0, jobsSucceeded: 1, jobsFailed: 0 }
   } catch (err) {
     // Fail path for job execution

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 
+import Redis from 'ioredis-mock'
 import {
   getCacheClient,
   shutdownCache,
@@ -7,36 +8,38 @@ import {
   getCache
 } from '../src/cache.js'
 
-beforeEach(shutdownCache)
-afterAll(shutdownCache)
-
-const options = {
+const opt = {
   cacheUri: 'redis://localhost',
   cacheTtlSeconds: 10,
-  cachePrefix: 'qdone:'
+  cachePrefix: 'qdone:',
+  Redis
 }
+
+beforeEach(shutdownCache)
+afterEach(async () => getCacheClient(opt).flushall())
+afterAll(shutdownCache)
 
 describe('getCacheClient', () => {
   test('throws an error for invalid cache uri', () => {
-    const badOptions = Object.assign({}, options, { cacheUri: 'bob://foo' })
-    expect(() => getCacheClient(badOptions)).toThrow('currently supported')
+    const badOpt = Object.assign({}, opt, { cacheUri: 'bob://foo' })
+    expect(() => getCacheClient(badOpt)).toThrow('currently supported')
   })
   test('throws an error when --cache-uri is missing', () => {
-    const badOptions = Object.assign({}, options)
-    delete badOptions.cacheUri
-    expect(() => getCacheClient(badOptions)).toThrow(/--cache-uri/)
+    const badOpt = Object.assign({}, opt)
+    delete badOpt.cacheUri
+    expect(() => getCacheClient(badOpt)).toThrow(/--cache-uri/)
   })
   test('supports redis:// URIs', () => {
-    expect(() => getCacheClient(options)).not.toThrow()
+    expect(() => getCacheClient(opt)).not.toThrow()
   })
   test('supports redis-cache:// URIs', () => {
     expect(() => getCacheClient(
-      Object.assign({}, options, { cacheUri: 'redis-cluster://' })
+      Object.assign({}, opt, { cacheUri: 'redis-cluster://' })
     )).not.toThrow()
   })
   test('returns an identical client on subsequent calls', () => {
-    const client1 = getCacheClient(options)
-    const client2 = getCacheClient(options)
+    const client1 = getCacheClient(opt)
+    const client2 = getCacheClient(opt)
     expect(client1).toEqual(client2)
   })
 })
@@ -44,21 +47,21 @@ describe('getCacheClient', () => {
 describe('setCache', function () {
   test('should successfully set a value', async () => {
     await expect(
-      setCache('test', { one: 1 }, options)
+      setCache('test', { one: 1 }, opt)
     ).resolves.toBe('OK')
   })
 })
 
 describe('getCache', function () {
   test('should return the same value that was set', async () => {
-    await setCache('test', { one: 1 }, options)
+    await setCache('test', { one: 1 }, opt)
     await expect(
-      getCache('test', options)
+      getCache('test', opt)
     ).resolves.toEqual({ one: 1 })
   })
   test('should return undefined for nonexistent keys', async () => {
     await expect(
-      getCache('supercalafragalisticexpealadocious', options)
+      getCache('supercalafragalisticexpealadocious', opt)
     ).resolves.toBeUndefined()
   })
 })

--- a/test/dedup.test.js
+++ b/test/dedup.test.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+import Redis from 'ioredis-mock'
+import { getOptionsWithDefaults } from '../src/defaults.js'
+import { shutdownCache, getCacheClient } from '../src/cache.js'
+import { getCacheKey, dedupShouldEnqueue } from '../src/dedup.js'
+
+const options = {
+  cacheUri: 'redis://localhost',
+  cacheTtlSeconds: 10,
+  cachePrefix: 'qdone:'
+}
+
+beforeEach(shutdownCache)
+afterEach(async () => getCacheClient(options).flushall())
+afterAll(shutdownCache)
+
+describe('getCacheKey', () => {
+  test('creates key based on prefix', () => {
+    const opt = getOptionsWithDefaults(options)
+    opt.Redis = new Redis({ data: {} })
+    expect(getCacheKey('ls -al', opt)).toEqual('qdone:dedup:ls -al')
+  })
+  test('ignores whitespace', () => {
+    const opt = getOptionsWithDefaults(options)
+    expect(getCacheKey(' ls -al    \t', opt)).toEqual('qdone:dedup:ls -al')
+  })
+})
+
+describe('dedupShouldEnqueue', () => {
+  test('resolves true if custom dedup is not enabled', async () => {
+    const opt = getOptionsWithDefaults(options)
+    opt.Redis = Redis
+    await expect(dedupShouldEnqueue('ls -al', opt)).resolves.toEqual(true)
+  })
+  test('resolves true if custom dedup is enabled and cache is empty', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({}, options, { dedupMethod: 'redis' }))
+    opt.Redis = Redis
+    await expect(dedupShouldEnqueue('ls -al', opt)).resolves.toEqual(true)
+  })
+  test('resolves false if custom dedup is enabled and cache is full', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({}, options, { dedupMethod: 'redis' }))
+    opt.Redis = Redis
+    await expect(dedupShouldEnqueue('ls -al', opt)).resolves.toEqual(true)
+    await expect(dedupShouldEnqueue('ls -al', opt)).resolves.toEqual(false)
+  })
+})

--- a/test/dedup.test.js
+++ b/test/dedup.test.js
@@ -3,7 +3,13 @@
 import Redis from 'ioredis-mock'
 import { getOptionsWithDefaults } from '../src/defaults.js'
 import { shutdownCache, getCacheClient } from '../src/cache.js'
-import { getCacheKey, dedupShouldEnqueue } from '../src/dedup.js'
+import {
+  getCacheKey,
+  dedupShouldEnqueue,
+  dedupShouldEnqueueMulti,
+  dedupSuccessfullyProcessed,
+  dedupSuccessfullyProcessedMulti
+} from '../src/dedup.js'
 
 const options = {
   cacheUri: 'redis://localhost',
@@ -16,14 +22,31 @@ afterEach(async () => getCacheClient(options).flushall())
 afterAll(shutdownCache)
 
 describe('getCacheKey', () => {
-  test('creates key based on prefix', () => {
+  test('creates key based on body when dedup id not specified', () => {
     const opt = getOptionsWithDefaults(options)
     opt.Redis = new Redis({ data: {} })
-    expect(getCacheKey('ls -al', opt)).toEqual('qdone:dedup:ls -al')
+    const message = { MessageBody: 'ls -al' }
+    expect(getCacheKey(message, opt)).toEqual('qdone:dedup:ls -al')
+  })
+  test('creates key based on dedup id when present', () => {
+    const opt = getOptionsWithDefaults(options)
+    opt.Redis = new Redis({ data: {} })
+    const message = {
+      MessageDeduplicationId: 'test',
+      MessageBody: 'ls -al'
+    }
+    expect(getCacheKey(message, opt)).toEqual('qdone:dedup:test')
+  })
+  test('creates key based on sha1 when body is too long', () => {
+    const opt = getOptionsWithDefaults(options)
+    opt.Redis = new Redis({ data: {} })
+    const message = { MessageBody: 'asdf '.repeat(1000) }
+    expect(getCacheKey(message, opt)).toEqual('qdone:dedup:asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asd...sha1:55c3f60a6c8ae4296dcb88aa7daaf8090d7622c6')
   })
   test('ignores whitespace', () => {
     const opt = getOptionsWithDefaults(options)
-    expect(getCacheKey(' ls -al    \t', opt)).toEqual('qdone:dedup:ls -al')
+    const message = { MessageBody: ' ls -al    \t' }
+    expect(getCacheKey(message, opt)).toEqual('qdone:dedup:ls -al')
   })
 })
 
@@ -31,17 +54,95 @@ describe('dedupShouldEnqueue', () => {
   test('resolves true if custom dedup is not enabled', async () => {
     const opt = getOptionsWithDefaults(options)
     opt.Redis = Redis
-    await expect(dedupShouldEnqueue('ls -al', opt)).resolves.toEqual(true)
+    const message = { MessageBody: 'ls -al' }
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
   })
   test('resolves true if custom dedup is enabled and cache is empty', async () => {
     const opt = getOptionsWithDefaults(Object.assign({}, options, { dedupMethod: 'redis' }))
     opt.Redis = Redis
-    await expect(dedupShouldEnqueue('ls -al', opt)).resolves.toEqual(true)
+    const message = { MessageBody: 'ls -al' }
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
   })
   test('resolves false if custom dedup is enabled and cache is full', async () => {
     const opt = getOptionsWithDefaults(Object.assign({}, options, { dedupMethod: 'redis' }))
     opt.Redis = Redis
-    await expect(dedupShouldEnqueue('ls -al', opt)).resolves.toEqual(true)
-    await expect(dedupShouldEnqueue('ls -al', opt)).resolves.toEqual(false)
+    const message = { MessageBody: 'ls -al' }
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(false)
+  })
+})
+
+describe('dedupShouldEnqueueMulti', () => {
+  test('leaves messages untouched if dedup is not enabled', async () => {
+    const opt = getOptionsWithDefaults(options)
+    opt.Redis = Redis
+    const message = { MessageBody: 'ls -al' }
+    const messages = [message, message, message]
+    await expect(dedupShouldEnqueueMulti(messages, opt)).resolves.toBe(messages)
+  })
+  test('only allows one of several duplicate messages', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
+    opt.Redis = Redis
+    const message = { MessageBody: 'ls -alh' }
+    const messages = [message, message, message, message]
+    await expect(dedupShouldEnqueueMulti(messages, opt)).resolves.toEqual([message])
+  })
+  test('allows multiple unique messages, preventing duplicates', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
+    opt.Redis = Redis
+    const message1 = { MessageBody: 'ls -alh 1' }
+    const message2 = { MessageBody: 'ls -alh 2' }
+    const message3 = { MessageBody: 'ls -alh 3' }
+    const messages = [message1, message1, message2, message2, message1, message2, message3]
+    await expect(dedupShouldEnqueueMulti(messages, opt)).resolves.toEqual([message1, message2, message3])
+  })
+})
+
+describe('dedupSuccessfullyProcessed', () => {
+  test('does nothing if dedup disabled', async () => {
+    const opt = getOptionsWithDefaults(options)
+    const message = { Body: 'ls -al' }
+    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(0)
+  })
+  test('shows one key deleted if called after dedupShouldEnqueue', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
+    opt.Redis = Redis
+    const message = { MessageBody: 'ls -alh' }
+    await dedupShouldEnqueue(message, opt)
+    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(1)
+  })
+  test('prevents duplicate enqueue but allows subsequent enqueue', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
+    opt.Redis = Redis
+    const message = { MessageBody: 'ls -alh' }
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(true)
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(false)
+    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(1)
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(true)
+  })
+})
+
+describe('dedupSuccessfullyProcessedMulti', () => {
+  test('does nothing if dedup disabled', async () => {
+    const opt = getOptionsWithDefaults(options)
+    const message1 = { Body: 'ls -alh 1' }
+    const message2 = { Body: 'ls -alh 2' }
+    const message3 = { Body: 'ls -alh 3' }
+    const messages = [message1, message1, message2, message2, message1, message2, message3]
+    await expect(dedupSuccessfullyProcessedMulti(messages, opt)).resolves.toBe(0)
+  })
+  test('shows the same number of keys deleted after call to dedupShouldEnqueueMulti', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
+    opt.Redis = Redis
+    const send1 = { MessageBody: 'ls -alh 1' }
+    const send2 = { MessageBody: 'ls -alh 2' }
+    const send3 = { MessageBody: 'ls -alh 3' }
+    const get1 = { Body: 'ls -alh 1' }
+    const get2 = { Body: 'ls -alh 2' }
+    const get3 = { Body: 'ls -alh 3' }
+    const sends = [send1, send2, send3]
+    const gets = [get1, get2, get3]
+    await dedupShouldEnqueueMulti(sends, opt)
+    await expect(dedupSuccessfullyProcessedMulti(gets, opt)).resolves.toEqual(3)
   })
 })

--- a/test/dedup.test.js
+++ b/test/dedup.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-
+import { jest } from '@jest/globals'
 import Redis from 'ioredis-mock'
 import { getOptionsWithDefaults } from '../src/defaults.js'
 import { shutdownCache, getCacheClient } from '../src/cache.js'
@@ -7,9 +7,12 @@ import {
   getCacheKey,
   getDeduplicationId,
   addDedupParamsToMessage,
-  calculateDedupParams,
   dedupShouldEnqueue,
-  dedupShouldEnqueueMulti
+  dedupShouldEnqueueMulti,
+  dedupSuccessfullyProcessed,
+  dedupSuccessfullyProcessedMulti,
+  updateStats,
+  statMaintenance
 } from '../src/dedup.js'
 
 const options = {
@@ -19,7 +22,10 @@ const options = {
 }
 
 beforeEach(shutdownCache)
-afterEach(async () => getCacheClient(options).flushall())
+afterEach(async () => {
+  jest.restoreAllMocks()
+  await getCacheClient(options).flushall()
+})
 afterAll(shutdownCache)
 
 describe('getDeduplicationId', () => {
@@ -53,12 +59,12 @@ describe('getCacheKey', () => {
 })
 
 describe('addDedupParamsToMessage', () => {
-  test('leaves non-fifo messages untouched', () => {
-    const opt = getOptionsWithDefaults({ ...options, fifo: false })
+  test('leaves non-fifo messages untouched when externalDedup is off', () => {
+    const opt = getOptionsWithDefaults({ ...options })
     const message = { MessageBody: 'test' }
     expect(addDedupParamsToMessage(message, opt)).toEqual({ ...message })
   })
-  test('adds params to fifo messages', () => {
+  test('adds MessageDeduplicationId to fifo messages', () => {
     const opt = getOptionsWithDefaults({ ...options, fifo: true })
     const message = { MessageBody: 'test' }
     expect(addDedupParamsToMessage(message, opt)).toEqual({ ...message, MessageDeduplicationId: 'test' })
@@ -68,18 +74,33 @@ describe('addDedupParamsToMessage', () => {
     const message = { MessageBody: 'test' }
     expect(addDedupParamsToMessage(message, opt)).toEqual({ ...message, MessageDeduplicationId: 'foo' })
   })
-  test('uses unique deduplication id when per message is requested', () => {
+  test('uses unique deduplication id when dedupIdPerMessage is set', () => {
     const opt = getOptionsWithDefaults({ ...options, fifo: true, dedupIdPerMessage: true })
     opt.uuidFunction = () => 'bar'
     const message = { MessageBody: 'test' }
     expect(addDedupParamsToMessage(message, opt)).toEqual({ ...message, MessageDeduplicationId: 'bar' })
   })
-  test('adds MessageAttribute when externalDedup is used', () => {
+  test('adds fake MessageDeduplicationId to when externalDedup is used on fifo', () => {
     const opt = getOptionsWithDefaults({ ...options, fifo: true, externalDedup: true })
+    opt.uuidFunction = () => 'fake-id'
     const message = { MessageBody: 'test' }
     const expected = {
       ...message,
-      MessageDeduplicationId: 'test',
+      MessageDeduplicationId: 'fake-id',
+      MessageAttributes: {
+        QdoneDeduplicationId: {
+          DataType: 'String',
+          StringValue: 'test'
+        }
+      }
+    }
+    expect(addDedupParamsToMessage(message, opt)).toEqual(expected)
+  })
+  test('still adds MessageAttribute when externalDedup is used on non-fifo', () => {
+    const opt = getOptionsWithDefaults({ ...options, externalDedup: true })
+    const message = { MessageBody: 'test' }
+    const expected = {
+      ...message,
       MessageAttributes: {
         QdoneDeduplicationId: {
           DataType: 'String',
@@ -91,35 +112,125 @@ describe('addDedupParamsToMessage', () => {
   })
 })
 
-describe('calculateDedupParams', () => {
-  test('calculates expected values when dedupPeriod is longer than min', async () => {
-    const dedupPeriod = 60 * 60
-    const opt = getOptionsWithDefaults({ ...options, dedupPeriod })
-    const timestamp = new Date().getTime()
-    const expected = { timestamp, minDedupPeriod: 360, dedupPeriod, canExpireAfter: Math.round(timestamp / 1000.0 + 360) }
-    expect(calculateDedupParams(opt)).toEqual(expected)
+describe('updateStats', () => {
+  test('updates duplicateSet and expirationSet keys', async () => {
+    const opt = getOptionsWithDefaults({ ...options })
+    const expireAt = new Date().getTime() + opt.dedupPeriod
+    const duplicateSet = opt.cachePrefix + 'dedup-stats:duplicateSet'
+    const expirationSet = opt.cachePrefix + 'dedup-stats:expirationSet'
+    await updateStats('test', 2, expireAt, opt)
+    await updateStats('test', 3, expireAt, opt)
+    await updateStats('test2', 2, expireAt, opt)
+    const client = getCacheClient(opt)
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, ['test2', '2', 'test', '3']],
+      [null, ['test', expireAt + '', 'test2', expireAt + '']]
+    ])
+  })
+  test('does nothing if duplicates is <1', async () => {
+    const opt = getOptionsWithDefaults({ ...options })
+    const expireAt = new Date().getTime() + opt.dedupPeriod
+    const duplicateSet = opt.cachePrefix + 'dedup-stats:duplicateSet'
+    const expirationSet = opt.cachePrefix + 'dedup-stats:expirationSet'
+    await updateStats('test', 0, expireAt, opt)
+    await updateStats('test', 0, expireAt, opt)
+    await updateStats('test2', 0, expireAt, opt)
+    const client = getCacheClient(opt)
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, []],
+      [null, []]
+    ])
+  })
+  test('works with a provided pipeline', async () => {
+    const opt = getOptionsWithDefaults({ ...options })
+    const expireAt = new Date().getTime() + opt.dedupPeriod
+    const duplicateSet = opt.cachePrefix + 'dedup-stats:duplicateSet'
+    const expirationSet = opt.cachePrefix + 'dedup-stats:expirationSet'
+    const client = getCacheClient(opt)
+    const pipeline = client.multi()
+    updateStats('test', 2, expireAt, opt, pipeline)
+    updateStats('test', 3, expireAt, opt, pipeline)
+    updateStats('test2', 2, expireAt, opt, pipeline)
+    await pipeline.exec()
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, ['test2', '2', 'test', '3']],
+      [null, ['test', expireAt + '', 'test2', expireAt + '']]
+    ])
+  })
+})
+
+describe('statMaintenance', () => {
+  test('clears out expired keys', async () => {
+    const opt = getOptionsWithDefaults({ ...options })
+    const duplicateSet = opt.cachePrefix + 'dedup-stats:duplicateSet'
+    const expirationSet = opt.cachePrefix + 'dedup-stats:expirationSet'
+    const expireAt = new Date().getTime() - 1
+    await updateStats('test', 2, expireAt, opt)
+    await updateStats('test', 3, expireAt, opt)
+    await updateStats('test2', 2, expireAt, opt)
+    const client = getCacheClient(opt)
+    await statMaintenance(opt)
+    await statMaintenance(opt)
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, []],
+      [null, []]
+    ])
   })
 })
 
 describe('dedupShouldEnqueue', () => {
-  test('resolves true if custom dedup is not enabled', async () => {
-    const opt = getOptionsWithDefaults(options)
-    opt.Redis = Redis
-    const message = { MessageBody: 'ls -al' }
-    await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
-  })
   test('resolves true if custom dedup is enabled and cache is empty', async () => {
     const opt = getOptionsWithDefaults(Object.assign({}, options, { externalDedup: true }))
     opt.Redis = Redis
-    const message = { MessageBody: 'ls -al' }
+    const message = addDedupParamsToMessage({ MessageBody: 'ls -al' }, opt)
     await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
   })
   test('resolves false if custom dedup is enabled and cache is full', async () => {
     const opt = getOptionsWithDefaults(Object.assign({}, options, { externalDedup: true }))
     opt.Redis = Redis
-    const message = { MessageBody: 'ls -al' }
+    const message = addDedupParamsToMessage({ MessageBody: 'ls -al' }, opt)
     await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
     await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(false)
+  })
+  test('updates stats if dedupStats is set', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({}, options, { externalDedup: true, dedupStats: true }))
+    const message = addDedupParamsToMessage({ MessageBody: 'ls -al' }, opt)
+    await dedupShouldEnqueue(message, opt)
+    const expireAt = new Date().getTime() + opt.dedupPeriod
+    await dedupShouldEnqueue(message, opt)
+    const duplicateSet = opt.cachePrefix + 'dedup-stats:duplicateSet'
+    const expirationSet = opt.cachePrefix + 'dedup-stats:expirationSet'
+    const client = getCacheClient(opt)
+    const expectedKey = opt.cachePrefix + 'dedup:ls_-al'
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, [expectedKey, '1']],
+      [null, [expectedKey, expireAt + '']]
+    ])
   })
 })
 
@@ -139,5 +250,174 @@ describe('dedupShouldEnqueueMulti', () => {
     const message3 = addDedupParamsToMessage({ MessageBody: 'ls -alh 3' }, opt)
     const messages = [message1, message1, message2, message2, message1, message2, message3]
     await expect(dedupShouldEnqueueMulti(messages, opt)).resolves.toEqual([message1, message2, message3])
+  })
+  test('updates stats if dedupStats is set', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({}, options, { externalDedup: true, dedupStats: true }))
+    const message1 = addDedupParamsToMessage({ MessageBody: 'ls -alh 1' }, opt)
+    const message2 = addDedupParamsToMessage({ MessageBody: 'ls -alh 2' }, opt)
+    const message3 = addDedupParamsToMessage({ MessageBody: 'ls -alh 3' }, opt)
+    const messages = [message1, message1, message2, message2, message2, message3]
+    const expireAt = new Date().getTime() + opt.dedupPeriod
+    await dedupShouldEnqueueMulti(messages, opt)
+    const duplicateSet = opt.cachePrefix + 'dedup-stats:duplicateSet'
+    const expirationSet = opt.cachePrefix + 'dedup-stats:expirationSet'
+    const client = getCacheClient(opt)
+    const expectedKey1 = opt.cachePrefix + 'dedup:ls_-alh_1'
+    const expectedKey2 = opt.cachePrefix + 'dedup:ls_-alh_2'
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, [expectedKey1, '1', expectedKey2, '2']],
+      [null, [expectedKey1, expireAt + '', expectedKey2, expireAt + '']]
+    ])
+  })
+})
+
+describe('dedupSuccessfullyProcessed', () => {
+  test('does nothing if dedup disabled', async () => {
+    const opt = getOptionsWithDefaults(options)
+    const message = { Body: 'ls -al' }
+    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(0)
+  })
+  test('shows one key deleted if called after dedupShouldEnqueue', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ externalDedup: true }, options))
+    opt.Redis = Redis
+    const message = addDedupParamsToMessage({ MessageBody: 'ls -alh' }, opt)
+    await dedupShouldEnqueue(message, opt)
+    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(1)
+  })
+  test('prevents duplicate enqueue but allows subsequent enqueue', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ externalDedup: true }, options))
+    opt.Redis = Redis
+    const message = addDedupParamsToMessage({ MessageBody: 'ls -alh' }, opt)
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(true)
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(false)
+    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(1)
+    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(true)
+  })
+  test('executes stat maintenance if needed', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ externalDedup: true, dedupStats: true }, options))
+    const message = addDedupParamsToMessage({ MessageBody: 'ls -alh' }, opt)
+    await dedupShouldEnqueue(message, opt)
+    const now = new Date()
+    const expireAt = now.getTime() + opt.dedupPeriod
+    await dedupShouldEnqueue(message, opt)
+
+    // Check stats exist
+    const duplicateSet = opt.cachePrefix + 'dedup-stats:duplicateSet'
+    const expirationSet = opt.cachePrefix + 'dedup-stats:expirationSet'
+    const client = getCacheClient(opt)
+    const expectedKey = opt.cachePrefix + 'dedup:ls_-alh'
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, [expectedKey, '1']],
+      [null, [expectedKey, expireAt + '']]
+    ])
+
+    // Fake out the random number geneartor
+    jest
+      .spyOn(Math, 'random')
+      .mockImplementation(() => 0.005)
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(1)
+    jest.restoreAllMocks()
+
+    // Check stats don't exist
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, []],
+      [null, []]
+    ])
+
+    // Cover branch where stat maintenance is not performed
+    await dedupSuccessfullyProcessed(message, opt)
+  })
+})
+
+describe('dedupSuccessfullyProcessedMulti', () => {
+  test('does nothing if dedup disabled', async () => {
+    const opt = getOptionsWithDefaults(options)
+    const message1 = addDedupParamsToMessage({ Body: 'ls -alh 1' }, opt)
+    const message2 = addDedupParamsToMessage({ Body: 'ls -alh 2' }, opt)
+    const message3 = addDedupParamsToMessage({ Body: 'ls -alh 3' }, opt)
+    const messages = [message1, message1, message2, message2, message1, message2, message3]
+    await expect(dedupSuccessfullyProcessedMulti(messages, opt)).resolves.toBe(0)
+  })
+  test('shows the same number of keys deleted after call to dedupShouldEnqueueMulti', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ externalDedup: true }, options))
+    opt.Redis = Redis
+    const send1 = addDedupParamsToMessage({ MessageBody: 'ls -alh 1' }, opt)
+    const send2 = addDedupParamsToMessage({ MessageBody: 'ls -alh 2' }, opt)
+    const send3 = addDedupParamsToMessage({ MessageBody: 'ls -alh 3' }, opt)
+    const get1 = { ...send1, Body: 'ls -alh 1' }
+    const get2 = { ...send2, Body: 'ls -alh 2' }
+    const get3 = { ...send3, Body: 'ls -alh 3' }
+    const sends = [send1, send2, send3]
+    const gets = [get1, get2, get3]
+    await dedupShouldEnqueueMulti(sends, opt)
+    await expect(dedupSuccessfullyProcessedMulti(gets, opt)).resolves.toEqual(3)
+  })
+  test('executes stat maintenance if needed', async () => {
+    const opt = getOptionsWithDefaults(Object.assign({ externalDedup: true, dedupStats: true }, options))
+    const now = new Date()
+    const expireAt = now.getTime() + opt.dedupPeriod
+    const send1 = addDedupParamsToMessage({ MessageBody: 'ls -alh 1' }, opt)
+    const send2 = addDedupParamsToMessage({ MessageBody: 'ls -alh 2' }, opt)
+    const send3 = addDedupParamsToMessage({ MessageBody: 'ls -alh 3' }, opt)
+    const get1 = { ...send1, Body: 'ls -alh 1' }
+    const get2 = { ...send2, Body: 'ls -alh 2' }
+    const get3 = { ...send3, Body: 'ls -alh 3' }
+    const sends = [send1, send1, send2, send2, send2, send3, send3, send3, send3]
+    const gets = [get1, get2, get3]
+    await dedupShouldEnqueueMulti(sends, opt)
+
+    // Check stats exist
+    const duplicateSet = opt.cachePrefix + 'dedup-stats:duplicateSet'
+    const expirationSet = opt.cachePrefix + 'dedup-stats:expirationSet'
+    const client = getCacheClient(opt)
+    const expectedKey1 = opt.cachePrefix + 'dedup:ls_-alh_1'
+    const expectedKey2 = opt.cachePrefix + 'dedup:ls_-alh_2'
+    const expectedKey3 = opt.cachePrefix + 'dedup:ls_-alh_3'
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, [expectedKey1, '1', expectedKey2, '2', expectedKey3, '3']],
+      [null, [expectedKey1, expireAt + '', expectedKey2, expireAt + '', expectedKey3, expireAt + '']]
+    ])
+
+    // Fake out the random number geneartor
+    jest
+      .spyOn(Math, 'random')
+      .mockImplementation(() => 2 / 100.0)
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    await expect(dedupSuccessfullyProcessedMulti(gets, opt)).resolves.toEqual(3)
+    jest.restoreAllMocks()
+
+    // Check stats don't exist
+    await expect(
+      client.multi()
+        .zrange(duplicateSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .zrange(expirationSet, '-inf', 'inf', 'BYSCORE', 'WITHSCORES')
+        .exec()
+    ).resolves.toEqual([
+      [null, []],
+      [null, []]
+    ])
+    // Cover branch where stats aren't erased
+    await dedupSuccessfullyProcessedMulti(gets, opt)
   })
 })

--- a/test/dedup.test.js
+++ b/test/dedup.test.js
@@ -5,10 +5,11 @@ import { getOptionsWithDefaults } from '../src/defaults.js'
 import { shutdownCache, getCacheClient } from '../src/cache.js'
 import {
   getCacheKey,
+  getDeduplicationId,
+  addDedupParamsToMessage,
+  calculateDedupParams,
   dedupShouldEnqueue,
-  dedupShouldEnqueueMulti,
-  dedupSuccessfullyProcessed,
-  dedupSuccessfullyProcessedMulti
+  dedupShouldEnqueueMulti
 } from '../src/dedup.js'
 
 const options = {
@@ -21,32 +22,82 @@ beforeEach(shutdownCache)
 afterEach(async () => getCacheClient(options).flushall())
 afterAll(shutdownCache)
 
-describe('getCacheKey', () => {
-  test('creates key based on body when dedup id not specified', () => {
+describe('getDeduplicationId', () => {
+  test('allows allowed characters', () => {
     const opt = getOptionsWithDefaults(options)
-    opt.Redis = new Redis({ data: {} })
-    const message = { MessageBody: 'ls -al' }
-    expect(getCacheKey(message, opt)).toEqual('qdone:dedup:ls -al')
+    expect(getDeduplicationId('a-zA-Z0-9!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~', opt)).toEqual('a-zA-Z0-9!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~')
   })
-  test('creates key based on dedup id when present', () => {
+  test('converts disallowed characters', () => {
     const opt = getOptionsWithDefaults(options)
-    opt.Redis = new Redis({ data: {} })
-    const message = {
-      MessageDeduplicationId: 'test',
-      MessageBody: 'ls -al'
-    }
-    expect(getCacheKey(message, opt)).toEqual('qdone:dedup:test')
+    expect(getDeduplicationId('éø¢‡ asdf', opt)).toEqual('_____asdf')
   })
-  test('creates key based on sha1 when body is too long', () => {
+  test('creates id based on sha1 when content is too long', () => {
     const opt = getOptionsWithDefaults(options)
-    opt.Redis = new Redis({ data: {} })
-    const message = { MessageBody: 'asdf '.repeat(1000) }
-    expect(getCacheKey(message, opt)).toEqual('qdone:dedup:asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asd...sha1:55c3f60a6c8ae4296dcb88aa7daaf8090d7622c6')
+    expect(getDeduplicationId('asdf '.repeat(1000), opt)).toEqual('asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_asdf_...sha1:ee08dd2964d1907d80f1ef743a595b5834c31170')
   })
   test('ignores whitespace', () => {
     const opt = getOptionsWithDefaults(options)
-    const message = { MessageBody: ' ls -al    \t' }
-    expect(getCacheKey(message, opt)).toEqual('qdone:dedup:ls -al')
+    expect(getDeduplicationId(' ls -al    \t', opt)).toEqual('ls_-al')
+  })
+})
+
+describe('getCacheKey', () => {
+  test('works with default prefix', () => {
+    const opt = getOptionsWithDefaults(options)
+    expect(getCacheKey('key', opt)).toEqual('qdone:dedup:key')
+  })
+  test('works with passed prefix', () => {
+    const opt = getOptionsWithDefaults({ ...options, cachePrefix: 'different:' })
+    expect(getCacheKey('key', opt)).toEqual('different:dedup:key')
+  })
+})
+
+describe('addDedupParamsToMessage', () => {
+  test('leaves non-fifo messages untouched', () => {
+    const opt = getOptionsWithDefaults({ ...options, fifo: false })
+    const message = { MessageBody: 'test' }
+    expect(addDedupParamsToMessage(message, opt)).toEqual({ ...message })
+  })
+  test('adds params to fifo messages', () => {
+    const opt = getOptionsWithDefaults({ ...options, fifo: true })
+    const message = { MessageBody: 'test' }
+    expect(addDedupParamsToMessage(message, opt)).toEqual({ ...message, MessageDeduplicationId: 'test' })
+  })
+  test('uses passed deduplication id when present', () => {
+    const opt = getOptionsWithDefaults({ ...options, fifo: true, deduplicationId: 'foo' })
+    const message = { MessageBody: 'test' }
+    expect(addDedupParamsToMessage(message, opt)).toEqual({ ...message, MessageDeduplicationId: 'foo' })
+  })
+  test('uses unique deduplication id when per message is requested', () => {
+    const opt = getOptionsWithDefaults({ ...options, fifo: true, dedupIdPerMessage: true })
+    opt.uuidFunction = () => 'bar'
+    const message = { MessageBody: 'test' }
+    expect(addDedupParamsToMessage(message, opt)).toEqual({ ...message, MessageDeduplicationId: 'bar' })
+  })
+  test('adds MessageAttribute when externalDedup is used', () => {
+    const opt = getOptionsWithDefaults({ ...options, fifo: true, externalDedup: true })
+    const message = { MessageBody: 'test' }
+    const expected = {
+      ...message,
+      MessageDeduplicationId: 'test',
+      MessageAttributes: {
+        QdoneDeduplicationId: {
+          DataType: 'String',
+          StringValue: 'test'
+        }
+      }
+    }
+    expect(addDedupParamsToMessage(message, opt)).toEqual(expected)
+  })
+})
+
+describe('calculateDedupParams', () => {
+  test('calculates expected values when dedupPeriod is longer than min', async () => {
+    const dedupPeriod = 60 * 60
+    const opt = getOptionsWithDefaults({ ...options, dedupPeriod })
+    const timestamp = new Date().getTime()
+    const expected = { timestamp, minDedupPeriod: 360, dedupPeriod, canExpireAfter: Math.round(timestamp / 1000.0 + 360) }
+    expect(calculateDedupParams(opt)).toEqual(expected)
   })
 })
 
@@ -58,13 +109,13 @@ describe('dedupShouldEnqueue', () => {
     await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
   })
   test('resolves true if custom dedup is enabled and cache is empty', async () => {
-    const opt = getOptionsWithDefaults(Object.assign({}, options, { dedupMethod: 'redis' }))
+    const opt = getOptionsWithDefaults(Object.assign({}, options, { externalDedup: true }))
     opt.Redis = Redis
     const message = { MessageBody: 'ls -al' }
     await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
   })
   test('resolves false if custom dedup is enabled and cache is full', async () => {
-    const opt = getOptionsWithDefaults(Object.assign({}, options, { dedupMethod: 'redis' }))
+    const opt = getOptionsWithDefaults(Object.assign({}, options, { externalDedup: true }))
     opt.Redis = Redis
     const message = { MessageBody: 'ls -al' }
     await expect(dedupShouldEnqueue(message, opt)).resolves.toEqual(true)
@@ -73,76 +124,20 @@ describe('dedupShouldEnqueue', () => {
 })
 
 describe('dedupShouldEnqueueMulti', () => {
-  test('leaves messages untouched if dedup is not enabled', async () => {
-    const opt = getOptionsWithDefaults(options)
-    opt.Redis = Redis
-    const message = { MessageBody: 'ls -al' }
-    const messages = [message, message, message]
-    await expect(dedupShouldEnqueueMulti(messages, opt)).resolves.toBe(messages)
-  })
   test('only allows one of several duplicate messages', async () => {
-    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
+    const opt = getOptionsWithDefaults(Object.assign({ externalDedup: true }, options))
     opt.Redis = Redis
     const message = { MessageBody: 'ls -alh' }
     const messages = [message, message, message, message]
     await expect(dedupShouldEnqueueMulti(messages, opt)).resolves.toEqual([message])
   })
   test('allows multiple unique messages, preventing duplicates', async () => {
-    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
+    const opt = getOptionsWithDefaults(Object.assign({ fifo: true, externalDedup: true }, options))
     opt.Redis = Redis
-    const message1 = { MessageBody: 'ls -alh 1' }
-    const message2 = { MessageBody: 'ls -alh 2' }
-    const message3 = { MessageBody: 'ls -alh 3' }
+    const message1 = addDedupParamsToMessage({ MessageBody: 'ls -alh 1' }, opt)
+    const message2 = addDedupParamsToMessage({ MessageBody: 'ls -alh 2' }, opt)
+    const message3 = addDedupParamsToMessage({ MessageBody: 'ls -alh 3' }, opt)
     const messages = [message1, message1, message2, message2, message1, message2, message3]
     await expect(dedupShouldEnqueueMulti(messages, opt)).resolves.toEqual([message1, message2, message3])
-  })
-})
-
-describe('dedupSuccessfullyProcessed', () => {
-  test('does nothing if dedup disabled', async () => {
-    const opt = getOptionsWithDefaults(options)
-    const message = { Body: 'ls -al' }
-    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(0)
-  })
-  test('shows one key deleted if called after dedupShouldEnqueue', async () => {
-    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
-    opt.Redis = Redis
-    const message = { MessageBody: 'ls -alh' }
-    await dedupShouldEnqueue(message, opt)
-    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(1)
-  })
-  test('prevents duplicate enqueue but allows subsequent enqueue', async () => {
-    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
-    opt.Redis = Redis
-    const message = { MessageBody: 'ls -alh' }
-    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(true)
-    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(false)
-    await expect(dedupSuccessfullyProcessed(message, opt)).resolves.toBe(1)
-    await expect(dedupShouldEnqueue(message, opt)).resolves.toBe(true)
-  })
-})
-
-describe('dedupSuccessfullyProcessedMulti', () => {
-  test('does nothing if dedup disabled', async () => {
-    const opt = getOptionsWithDefaults(options)
-    const message1 = { Body: 'ls -alh 1' }
-    const message2 = { Body: 'ls -alh 2' }
-    const message3 = { Body: 'ls -alh 3' }
-    const messages = [message1, message1, message2, message2, message1, message2, message3]
-    await expect(dedupSuccessfullyProcessedMulti(messages, opt)).resolves.toBe(0)
-  })
-  test('shows the same number of keys deleted after call to dedupShouldEnqueueMulti', async () => {
-    const opt = getOptionsWithDefaults(Object.assign({ dedupMethod: 'redis' }, options))
-    opt.Redis = Redis
-    const send1 = { MessageBody: 'ls -alh 1' }
-    const send2 = { MessageBody: 'ls -alh 2' }
-    const send3 = { MessageBody: 'ls -alh 3' }
-    const get1 = { Body: 'ls -alh 1' }
-    const get2 = { Body: 'ls -alh 2' }
-    const get3 = { Body: 'ls -alh 3' }
-    const sends = [send1, send2, send3]
-    const gets = [get1, get2, get3]
-    await dedupShouldEnqueueMulti(sends, opt)
-    await expect(dedupSuccessfullyProcessedMulti(gets, opt)).resolves.toEqual(3)
   })
 })

--- a/test/enqueue.test.js
+++ b/test/enqueue.test.js
@@ -136,7 +136,6 @@ describe('getOrCreateQueue', () => {
   })
 
   test('fifo variant of above', async () => {
-    console.error('fifo variant')
     const opt = getOptionsWithDefaults({ prefix: '', dlq: true, fifo: true, verbose: true })
     const basename = 'testqueue'
     const qname = basename + '.fifo'
@@ -172,7 +171,6 @@ describe('getOrCreateQueue', () => {
   })
 
   test('tag variant of above', async () => {
-    console.error('fifo variant')
     const tags = { Role: 'app', Environment: 'production' }
     const opt = getOptionsWithDefaults({ prefix: '', dlq: true, fifo: true, verbose: true, tags })
     const basename = 'testqueue'
@@ -1243,13 +1241,10 @@ describe('enqueueBatch', () => {
     sqsMock
       .on(GetQueueUrlCommand)
       .callsFake(({ QueueName: qname }) => {
-        // console.log({ GetQueueUrlCommand: { QueueName: qname } })
         return { QueueUrl: qrlBase + qname }
       })
       .on(SendMessageBatchCommand)
       .callsFake(async ({ Entries: entries, QueueUrl: qrl }) => {
-        // console.log({ SendMessageBatchCommand: { Entries: entries,  QueueUrl: qrl } })
-        // console.log(entries)
         return {
           Successful: entries
             .filter(({ MessageGroupId, MessageDeduplicationId }) =>


### PR DESCRIPTION
Needed for suredone/suredone#10018

## Changelog

- Adds the `dedupMethod` option to the enqueue, worker and scheduler APIs. A value of `redis` here instead of the default `sqs` will use the redis cluster to deduplicate jobs based on their command line content.
- This style of dedup is a "only one in queue" method, that only allows one job with that exact command line in any queue.
-- Adds the `dedupPeriod` option which is how long the command may be in the queue before allowing another