### PR TITLE
Return deduplicationId to callers of enqueue() and enqueueBatch()

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "qdone",
-  "version": "2.0.46-alpha",
+  "version": "2.0.47-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qdone",
-      "version": "2.0.46-alpha",
+      "version": "2.0.47-alpha",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "3.465.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "qdone",
-  "version": "2.0.47-alpha",
+  "version": "2.0.48-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qdone",
-      "version": "2.0.47-alpha",
+      "version": "2.0.48-alpha",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "3.465.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qdone",
-  "version": "2.0.46-alpha",
+  "version": "2.0.47-alpha",
   "description": "A distributed scheduler for SQS",
   "type": "module",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qdone",
-  "version": "2.0.47-alpha",
+  "version": "2.0.48-alpha",
   "description": "A distributed scheduler for SQS",
   "type": "module",
   "main": "./index.js",

--- a/src/enqueue.js
+++ b/src/enqueue.js
@@ -276,7 +276,18 @@ export async function sendMessageBatch (qrl, messages, opt) {
     const promises = params.Entries.map(async m => ({ m, shouldEnqueue: await dedupShouldEnqueue(m, opt) }))
     const results = await Promise.all(promises)
     params.Entries = results.filter(({ shouldEnqueue }) => shouldEnqueue).map(({ m }) => m)
-    if (!params.Entries.length) return { Failed: [], Successful: [] }
+    if (!params.Entries.length) {
+      const result = {
+        Failed: [],
+        Successful: results.map(
+          ({ m: { Id: id, MessageAttributes: ma } }) => ({
+            Id: id,
+            MessageId: 'duplicate',
+            QdoneDeduplicationId: ma?.QdoneDeduplicationId?.StringValue
+          }))
+      }
+      return result
+    }
   }
 
   // Send them

--- a/src/enqueue.js
+++ b/src/enqueue.js
@@ -333,10 +333,25 @@ let requestCount = 0
 //
 export async function flushMessages (qrl, opt, sendBuffer) {
   debug('flushMessages', qrl)
+  // Track our outgoing messages to map with Failed / Successful returns
+  const messagesById = new Map()
+  const resultsById = new Map()
+  const results = []
+  if (sendBuffer[qrl] && sendBuffer[qrl].length) {
+    for (const message of sendBuffer[qrl]) {
+      messagesById.set(message.Id, message)
+      // Pre-prepare results
+      const result = {}
+      resultsById.set(message.Id, result)
+      results.push(result)
+    }
+  }
   // Flush until empty
   let numFlushed = 0
   async function whileNotEmpty () {
-    if (!(sendBuffer[qrl] && sendBuffer[qrl].length)) return numFlushed
+    if (!(sendBuffer[qrl] && sendBuffer[qrl].length)) {
+      return { numFlushed, results }
+    }
     // Construct batch until full
     const batch = []
     let nextSize = JSON.stringify(sendBuffer[qrl][0]).length
@@ -362,9 +377,13 @@ export async function flushMessages (qrl, opt, sendBuffer) {
     // If we actually managed to flush any of them
     if (batch.length) {
       requestCount += 1
-      data.Successful.forEach(message => {
-        if (opt.verbose) console.error(chalk.blue('Enqueued job ') + message.MessageId + chalk.blue(' request ' + requestCount))
-      })
+      for (const { Id, MessageId } of data.Successful) {
+        const { MessageAttributes } = messagesById.get(Id)
+        if (MessageAttributes?.QdoneDeduplicaitonId?.StringValue) {
+          resultsById.get(Id).QdoneDeduplicaitonId = MessageAttributes?.QdoneDeduplicaitonId?.StringValue
+        }
+        if (opt.verbose) console.error(chalk.blue('Enqueued job ') + MessageId + chalk.blue(' request ' + requestCount))
+      }
       numFlushed += batch.length
     }
     return whileNotEmpty()
@@ -385,7 +404,7 @@ export async function addMessage (qrl, command, messageIndex, opt, sendBuffer, m
   if (sendBuffer[qrl].length >= 10) {
     return flushMessages(qrl, opt, sendBuffer)
   }
-  return 0
+  return { numFlushed: 0, results: [] }
 }
 
 //
@@ -418,6 +437,7 @@ export async function enqueueBatch (pairs, options) {
     setExtra({ qdoneOperation: 'enqueueBatch', args: { pairs, opt } })
   }
   try {
+    const allResults = []
     // Find unique queues so we can pre-fetch qrls. We do this so that all
     // queues are created prior to going through our flush logic
     const normalizedPairs = pairs.map(({ queue, command, messageOptions }) => ({
@@ -441,7 +461,9 @@ export async function enqueueBatch (pairs, options) {
     let initialFlushTotal = 0
     for (const { qname, command, messageOptions } of normalizedPairs) {
       const qrl = await getOrCreateQueue(qname, opt)
-      initialFlushTotal += await addMessage(qrl, command, messageIndex++, opt, sendBuffer, messageOptions)
+      const { numFlushed, results } = await addMessage(qrl, command, messageIndex++, opt, sendBuffer, messageOptions)
+      initialFlushTotal += numFlushed
+      allResults.push(...results)
     }
 
     // And flush any remaining messages
@@ -449,11 +471,14 @@ export async function enqueueBatch (pairs, options) {
     for (const qrl in sendBuffer) {
       extraFlushPromises.push(flushMessages(qrl, opt, sendBuffer))
     }
-    const extraFlushCounts = await Promise.all(extraFlushPromises)
-    const extraFlushTotal = extraFlushCounts.reduce((a, b) => a + b, 0)
+    let extraFlushTotal = 0
+    for (const { numFlushed, results } of await Promise.all(extraFlushPromises)) {
+      allResults.push(...results)
+      extraFlushTotal += numFlushed
+    }
     const totalFlushed = initialFlushTotal + extraFlushTotal
     debug({ initialFlushTotal, extraFlushTotal, totalFlushed })
-    return totalFlushed
+    return { numFlushed: totalFlushed, results: allResults }
   } catch (e) {
     console.log(e)
     throw e

--- a/src/enqueue.js
+++ b/src/enqueue.js
@@ -332,17 +332,18 @@ let requestCount = 0
 // Returns number of messages flushed.
 //
 export async function flushMessages (qrl, opt, sendBuffer) {
-  debug('flushMessages', qrl)
+  debug('flushMessages', { qrl, sendBuffer })
   // Track our outgoing messages to map with Failed / Successful returns
   const messagesById = new Map()
   const resultsById = new Map()
   const results = []
   if (sendBuffer[qrl] && sendBuffer[qrl].length) {
     for (const message of sendBuffer[qrl]) {
-      messagesById.set(message.Id, message)
+      const Id = message.Id
+      messagesById.set(Id, message)
       // Pre-prepare results
-      const result = {}
-      resultsById.set(message.Id, result)
+      const result = { Id }
+      resultsById.set(Id, result)
       results.push(result)
     }
   }
@@ -365,10 +366,9 @@ export async function flushMessages (qrl, opt, sendBuffer) {
 
     // Send batch
     const data = await sendMessageBatch(qrl, batch, opt)
-    debug({ data })
 
     // Fail if there are any individual message failures
-    if (data.Failed && data.Failed.length) {
+    if (data?.Failed && data?.Failed.length) {
       const err = new Error('One or more message failures: ' + JSON.stringify(data.Failed))
       err.Failed = data.Failed
       throw err
@@ -377,12 +377,17 @@ export async function flushMessages (qrl, opt, sendBuffer) {
     // If we actually managed to flush any of them
     if (batch.length) {
       requestCount += 1
-      for (const { Id, MessageId } of data.Successful) {
-        const { MessageAttributes } = messagesById.get(Id)
-        if (MessageAttributes?.QdoneDeduplicaitonId?.StringValue) {
-          resultsById.get(Id).QdoneDeduplicaitonId = MessageAttributes?.QdoneDeduplicaitonId?.StringValue
+      if (data?.Successful) {
+        for (const { Id, MessageId } of data.Successful) {
+          const result = resultsById.get(Id)
+          const message = messagesById.get(Id)
+          result.MessageId = MessageId
+          result.Id = Id
+          if (message?.MessageAttributes?.QdoneDeduplicationId?.StringValue) {
+            result.QdoneDeduplicationId = message?.MessageAttributes?.QdoneDeduplicationId?.StringValue
+          }
+          if (opt.verbose) console.error(chalk.blue('Enqueued job ') + MessageId + chalk.blue(' request ' + requestCount))
         }
-        if (opt.verbose) console.error(chalk.blue('Enqueued job ') + MessageId + chalk.blue(' request ' + requestCount))
       }
       numFlushed += batch.length
     }
@@ -396,11 +401,12 @@ export async function flushMessages (qrl, opt, sendBuffer) {
 // Automaticaly flushes if queue has >= 10 messages.
 // Returns number of messages flushed.
 //
+const debugAddMessage = Debug('qdone:enqueue:addMessage')
 export async function addMessage (qrl, command, messageIndex, opt, sendBuffer, messageOptions) {
   const message = formatMessage(command, messageIndex, opt, messageOptions)
   sendBuffer[qrl] = sendBuffer[qrl] || []
   sendBuffer[qrl].push(message)
-  debug({ location: 'addMessage', sendBuffer })
+  debugAddMessage({ location: 'addMessage', messageIndex, sendBuffer })
   if (sendBuffer[qrl].length >= 10) {
     return flushMessages(qrl, opt, sendBuffer)
   }

--- a/test/enqueue.test.js
+++ b/test/enqueue.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals'
+import { error } from 'console'
 import {
   CreateQueueCommand,
   GetQueueUrlCommand,
@@ -486,10 +487,10 @@ describe('sendMessage', () => {
     setSQSClient(sqsMock)
     sqsMock
       .on(SendMessageCommand, { QueueUrl: qrl })
-      .resolves({ MD5OfMessageBody: md5, MessageId: messageId })
+      .resolves({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     await expect(
       sendMessage(qrl, cmd, options)
-    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId })
+    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(
         1,
@@ -512,10 +513,10 @@ describe('sendMessage', () => {
     setSQSClient(sqsMock)
     sqsMock
       .on(SendMessageCommand, { QueueUrl: qrl })
-      .resolves({ MD5OfMessageBody: md5, MessageId: messageId })
+      .resolves({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     await expect(
       sendMessage(qrl, cmd, opt)
-    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId })
+    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     expect(sqsMock).toHaveReceivedNthCommandWith(
       1, SendMessageCommand,
       Object.assign({}, formatMessage(cmd, null, opt), { QueueUrl: qrl, MessageGroupId: opt.groupId })
@@ -541,10 +542,10 @@ describe('sendMessage', () => {
     setSQSClient(sqsMock)
     sqsMock
       .on(SendMessageCommand, { QueueUrl: qrl })
-      .resolves({ MD5OfMessageBody: md5, MessageId: messageId })
+      .resolves({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     await expect(
       sendMessage(qrl, cmd, opt)
-    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId })
+    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     expect(sqsMock)
       .toHaveReceivedNthCommandWith(
         1,
@@ -579,7 +580,7 @@ describe('sendMessage', () => {
       .rejectsOnce(new RequestThrottled())
       // .rejectsOnce(new KmsThrottled())
       // .rejectsOnce(new QueueDoesNotExist())
-      .resolvesOnce({ MD5OfMessageBody: md5, MessageId: messageId })
+      .resolvesOnce({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     const promise = sendMessage(qrl, cmd, opt)
 
     await Promise.resolve() // shouldRetry()
@@ -590,7 +591,7 @@ describe('sendMessage', () => {
     await Promise.resolve() // await action
     jest.runAllTimers() // not sure why here
 
-    await expect(promise).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId })
+    await expect(promise).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     expect(sqsMock)
       .toHaveReceivedNthCommandWith(
         2,
@@ -616,10 +617,10 @@ describe('sendMessageBatch', () => {
     setSQSClient(sqsMock)
     sqsMock
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
-      .resolves({ MD5OfMessageBody: md5, MessageId: messageId })
+      .resolves({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     await expect(
       sendMessageBatch(qrl, messages, opt)
-    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId })
+    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(
         1,
@@ -646,10 +647,10 @@ describe('sendMessageBatch', () => {
     setSQSClient(sqsMock)
     sqsMock
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
-      .resolves({ MD5OfMessageBody: md5, MessageId: messageId })
+      .resolves({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     await expect(
       sendMessageBatch(qrl, messages, options)
-    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId })
+    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(
         1,
@@ -682,16 +683,16 @@ describe('sendMessageBatch', () => {
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolves({
         Succeeded: [
-          { MD5OfMessageBody: md5, MessageId: messageId, MessageGroupId: groupId },
-          { MD5OfMessageBody: md5, MessageId: messageId, MessageGroupId: groupId }
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1', MessageGroupId: groupId },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1', MessageGroupId: groupId }
         ]
       })
     await expect(
       sendMessageBatch(qrl, messages, options)
     ).resolves.toEqual({
       Succeeded: [
-        { MD5OfMessageBody: md5, MessageId: messageId, MessageGroupId: groupId },
-        { MD5OfMessageBody: md5, MessageId: messageId, MessageGroupId: groupId }
+        { MD5OfMessageBody: md5, MessageId: messageId, Id: '1', MessageGroupId: groupId },
+        { MD5OfMessageBody: md5, MessageId: messageId, Id: '1', MessageGroupId: groupId }
       ]
     })
     expect(sqsMock)
@@ -725,16 +726,16 @@ describe('sendMessageBatch', () => {
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolves({
         Succeeded: [
-          { MD5OfMessageBody: md5, MessageId: messageId, MessageGroupId: groupId },
-          { MD5OfMessageBody: md5, MessageId: messageId, MessageGroupId: groupId }
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1', MessageGroupId: groupId },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1', MessageGroupId: groupId }
         ]
       })
     await expect(
       sendMessageBatch(qrl, messages, options)
     ).resolves.toEqual({
       Succeeded: [
-        { MD5OfMessageBody: md5, MessageId: messageId, MessageGroupId: groupId },
-        { MD5OfMessageBody: md5, MessageId: messageId, MessageGroupId: groupId }
+        { MD5OfMessageBody: md5, MessageId: messageId, Id: '1', MessageGroupId: groupId },
+        { MD5OfMessageBody: md5, MessageId: messageId, Id: '1', MessageGroupId: groupId }
       ]
     })
     expect(sqsMock)
@@ -750,7 +751,7 @@ describe('addMessage / flushMessages', () => {
   test('basic add/flush cycle works', async () => {
     const options = {}
     const opt = getOptionsWithDefaults(options)
-    const qname = 'testqueue'
+    const qname = 'testqueueFlushMessages'
     const qrl = `https://sqs.us-east-1.amazonaws.com/foobar/${qname}`
     const cmd = 'sd BulkStatusModel finalizeAll'
     const sqsMock = mockClient(client)
@@ -775,30 +776,41 @@ describe('addMessage / flushMessages', () => {
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolvesOnce({
         Successful: [
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId }
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '2' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '3' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '4' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '5' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '6' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '7' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '8' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '9' },
         ]
       })
       .resolvesOnce({
         Successful: [
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId }
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '10' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '11' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '12' }
         ]
       })
 
     // And the next one should flush all 10
     expect(addMessage(qrl, cmd, 9, options, sendBuffer)).resolves.toEqual({
       numFlushed: 10,
-      results: Array(10).fill({ MessageId: messageId })
+      results: [
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' },
+        { MessageId: messageId, Id: '2' },
+        { MessageId: messageId, Id: '3' },
+        { MessageId: messageId, Id: '4' },
+        { MessageId: messageId, Id: '5' },
+        { MessageId: messageId, Id: '6' },
+        { MessageId: messageId, Id: '7' },
+        { MessageId: messageId, Id: '8' },
+        { MessageId: messageId, Id: '9' }
+      ]
     })
 
     // And add three more
@@ -809,9 +821,9 @@ describe('addMessage / flushMessages', () => {
     await expect(flushMessages(qrl, options, sendBuffer)).resolves.toEqual({
       numFlushed: 3,
       results: [
-        { MessageId: messageId },
-        { MessageId: messageId },
-        { MessageId: messageId }
+        { MessageId: messageId, Id: '10' },
+        { MessageId: messageId, Id: '11' },
+        { MessageId: messageId, Id: '12' }
       ]
     })
     expect(sqsMock)
@@ -849,6 +861,66 @@ describe('addMessage / flushMessages', () => {
       )
   })
 
+  test('dedup id is returned when activated', async () => {
+    const options = {
+      // externalDedup: true,
+      cacheUri: 'redis://localhost',
+      cachePrefix: 'qdone:enqueue:',
+      cacheTtlSeconds: 1
+    }
+    const opt = getOptionsWithDefaults(options)
+    const qname = 'testqueueDedupIdReturn'
+    const qrl = `https://sqs.us-east-1.amazonaws.com/foobar/${qname}`
+    const cmd = 'sd BulkStatusModel finalizeAll'
+    const sqsMock = mockClient(client)
+    const messageId = '1e0632f4-b9e8-4f5c-a8e2-3529af1a56d6'
+    const md5 = 'foobar'
+    const message = {
+      MessageBody: 'sd BulkStatusModel finalizeAll',
+      Id: '0',
+      MessageAttributes: {
+        QdoneDeduplicationId: {
+          StringValue: 'sha1:{ed646457f61480d6b4b8441d1e192fa1be44e561}:body:sd_BulkStatusModel_finalizeAll',
+          DataType: 'String'
+        }
+      }
+    }
+    const sendBuffer = {
+      [qrl]: [message]
+    }
+
+    setSQSClient(sqsMock)
+    sqsMock
+      .on(SendMessageBatchCommand, { QueueUrl: qrl })
+      .resolvesOnce({
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+        ]
+      })
+
+    await expect(flushMessages(qrl, opt, sendBuffer)).resolves.toEqual({
+      numFlushed: 1,
+      results: [
+        {
+          Id: '0',
+          MessageId: messageId,
+          QdoneDeduplicationId: 'sha1:{ed646457f61480d6b4b8441d1e192fa1be44e561}:body:sd_BulkStatusModel_finalizeAll'
+        }
+      ]
+    })
+
+    expect(sqsMock)
+      .toHaveReceivedNthSpecificCommandWith(
+        1,
+        SendMessageBatchCommand,
+        Object.assign({
+          QueueUrl: qrl,
+          Entries: [message]
+        })
+      )
+
+  })
+
   test('failed messages fail the whole batch', async () => {
     const options = { dlq: false }
     const opt = getOptionsWithDefaults(options)
@@ -877,22 +949,22 @@ describe('addMessage / flushMessages', () => {
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolvesOnce({
         Successful: [
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId }
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '2' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '3' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '4' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '5' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '6' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '7' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '8' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '9' }
         ]
       })
       .resolvesOnce({
         Successful: [
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId }
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '10' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '11' }
         ],
         Failed: [
           { SenderFault: true, Id: '25', Code: 'XYZ', Message: 'You messed up.' }
@@ -902,7 +974,18 @@ describe('addMessage / flushMessages', () => {
     // And the next one should flush all 10
     expect(addMessage(qrl, cmd, 9, opt, sendBuffer)).resolves.toEqual({
       numFlushed: 10,
-      results: Array(10).fill({ MessageId: messageId })
+      results: [
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' },
+        { MessageId: messageId, Id: '2' },
+        { MessageId: messageId, Id: '3' },
+        { MessageId: messageId, Id: '4' },
+        { MessageId: messageId, Id: '5' },
+        { MessageId: messageId, Id: '6' },
+        { MessageId: messageId, Id: '7' },
+        { MessageId: messageId, Id: '8' },
+        { MessageId: messageId, Id: '9' }
+      ]
     })
 
     // And add three more
@@ -963,10 +1046,10 @@ describe('enqueue', () => {
       .on(GetQueueUrlCommand, { QueueName: qname })
       .resolves({ QueueUrl: qrl })
       .on(SendMessageCommand, { QueueUrl: qrl })
-      .resolves({ MD5OfMessageBody: md5, MessageId: messageId })
+      .resolves({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     await expect(
       enqueue(qname, cmd, options)
-    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId })
+    ).resolves.toEqual({ MD5OfMessageBody: md5, MessageId: messageId, Id: '1' })
     expect(sqsMock)
       .toHaveReceivedNthCommandWith(1, GetQueueUrlCommand, { QueueName: qname })
     expect(sqsMock)
@@ -1114,8 +1197,8 @@ describe('enqueueBatch', () => {
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolves({
         Successful: [
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId }
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1' }
         ]
       })
     await expect(
@@ -1123,8 +1206,8 @@ describe('enqueueBatch', () => {
     ).resolves.toEqual({
       numFlushed: 2,
       results: [
-        { MessageId: messageId },
-        { MessageId: messageId }
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' }
       ]
     })
     expect(sqsMock)
@@ -1153,13 +1236,40 @@ describe('enqueueBatch', () => {
       .resolves({ QueueUrl: qrl })
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolvesOnce({
-        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '2' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '3' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '4' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '5' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '6' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '7' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '8' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '9' }
+        ]
       })
       .resolvesOnce({
-        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '10' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '11' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '12' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '13' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '14' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '15' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '16' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '17' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '18' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '19' }
+        ]
       })
       .resolvesOnce({
-        Successful: Array(4).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '20' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '21' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '22' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '23' }
+        ]
       })
 
     const pairs = await loadBatchFiles(['test/fixtures/test-unique01-x24.batch'])
@@ -1167,7 +1277,32 @@ describe('enqueueBatch', () => {
 
     await expect(enqueueBatch(pairs, opt)).resolves.toEqual({
       numFlushed: 24,
-      results: Array(24).fill({ MessageId: messageId })
+      results: [
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' },
+        { MessageId: messageId, Id: '2' },
+        { MessageId: messageId, Id: '3' },
+        { MessageId: messageId, Id: '4' },
+        { MessageId: messageId, Id: '5' },
+        { MessageId: messageId, Id: '6' },
+        { MessageId: messageId, Id: '7' },
+        { MessageId: messageId, Id: '8' },
+        { MessageId: messageId, Id: '9' },
+        { MessageId: messageId, Id: '10' },
+        { MessageId: messageId, Id: '11' },
+        { MessageId: messageId, Id: '12' },
+        { MessageId: messageId, Id: '13' },
+        { MessageId: messageId, Id: '14' },
+        { MessageId: messageId, Id: '15' },
+        { MessageId: messageId, Id: '16' },
+        { MessageId: messageId, Id: '17' },
+        { MessageId: messageId, Id: '18' },
+        { MessageId: messageId, Id: '19' },
+        { MessageId: messageId, Id: '20' },
+        { MessageId: messageId, Id: '21' },
+        { MessageId: messageId, Id: '22' },
+        { MessageId: messageId, Id: '23' }
+      ]
     })
 
     expect(sqsMock).toHaveReceivedCommandTimes(GetQueueUrlCommand, 1)
@@ -1188,13 +1323,40 @@ describe('enqueueBatch', () => {
       .resolves({ QueueUrl: qrl })
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolvesOnce({
-        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '2' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '3' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '4' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '5' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '6' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '7' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '8' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '9' }
+        ]
       })
       .resolvesOnce({
-        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '10' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '11' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '12' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '13' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '14' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '15' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '16' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '17' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '18' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '19' }
+        ]
       })
       .resolvesOnce({
-        Successful: Array(4).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '20' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '21' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '22' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '23' }
+        ]
       })
 
     const pairs = await loadBatchFiles(['test/fixtures/test-unique01-x24.batch'])
@@ -1202,7 +1364,32 @@ describe('enqueueBatch', () => {
 
     await expect(enqueueBatch(pairs, opt)).resolves.toEqual({
       numFlushed: 24,
-      results: Array(24).fill({ MessageId: messageId })
+      results: [
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' },
+        { MessageId: messageId, Id: '2' },
+        { MessageId: messageId, Id: '3' },
+        { MessageId: messageId, Id: '4' },
+        { MessageId: messageId, Id: '5' },
+        { MessageId: messageId, Id: '6' },
+        { MessageId: messageId, Id: '7' },
+        { MessageId: messageId, Id: '8' },
+        { MessageId: messageId, Id: '9' },
+        { MessageId: messageId, Id: '10' },
+        { MessageId: messageId, Id: '11' },
+        { MessageId: messageId, Id: '12' },
+        { MessageId: messageId, Id: '13' },
+        { MessageId: messageId, Id: '14' },
+        { MessageId: messageId, Id: '15' },
+        { MessageId: messageId, Id: '16' },
+        { MessageId: messageId, Id: '17' },
+        { MessageId: messageId, Id: '18' },
+        { MessageId: messageId, Id: '19' },
+        { MessageId: messageId, Id: '20' },
+        { MessageId: messageId, Id: '21' },
+        { MessageId: messageId, Id: '22' },
+        { MessageId: messageId, Id: '23' }
+      ]
     })
 
     expect(sqsMock).toHaveReceivedCommandTimes(GetQueueUrlCommand, 1)
@@ -1223,13 +1410,40 @@ describe('enqueueBatch', () => {
       .resolves({ QueueUrl: qrl })
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolvesOnce({
-        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '2' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '3' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '4' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '5' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '6' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '7' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '8' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '9' }
+        ]
       })
       .resolvesOnce({
-        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '10' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '11' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '12' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '13' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '14' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '15' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '16' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '17' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '18' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '19' }
+        ]
       })
       .resolvesOnce({
-        Successful: Array(4).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '20' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '21' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '22' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '23' }
+        ]
       })
 
     const pairs = await loadBatchFiles(['test/fixtures/test-unique01-x24.batch'])
@@ -1237,7 +1451,32 @@ describe('enqueueBatch', () => {
 
     await expect(enqueueBatch(pairs, opt)).resolves.toEqual({
       numFlushed: 24,
-      results: Array(24).fill({ MessageId: messageId })
+      results: [
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' },
+        { MessageId: messageId, Id: '2' },
+        { MessageId: messageId, Id: '3' },
+        { MessageId: messageId, Id: '4' },
+        { MessageId: messageId, Id: '5' },
+        { MessageId: messageId, Id: '6' },
+        { MessageId: messageId, Id: '7' },
+        { MessageId: messageId, Id: '8' },
+        { MessageId: messageId, Id: '9' },
+        { MessageId: messageId, Id: '10' },
+        { MessageId: messageId, Id: '11' },
+        { MessageId: messageId, Id: '12' },
+        { MessageId: messageId, Id: '13' },
+        { MessageId: messageId, Id: '14' },
+        { MessageId: messageId, Id: '15' },
+        { MessageId: messageId, Id: '16' },
+        { MessageId: messageId, Id: '17' },
+        { MessageId: messageId, Id: '18' },
+        { MessageId: messageId, Id: '19' },
+        { MessageId: messageId, Id: '20' },
+        { MessageId: messageId, Id: '21' },
+        { MessageId: messageId, Id: '22' },
+        { MessageId: messageId, Id: '23' }
+      ]
     })
 
     expect(sqsMock).toHaveReceivedCommandTimes(GetQueueUrlCommand, 1)
@@ -1315,11 +1554,43 @@ describe('enqueueBatch', () => {
     const second = enqueueBatch(pairs.map(p => ({ queue: qname3, command: cmd })), { ...opt, fifo: true })
     await expect(first).resolves.toEqual({
       numFlushed: 15,
-      results: Array(15).fill({ MessageId: undefined })
+      results: [
+        { Id: '0' },
+        { Id: '1' },
+        { Id: '2' },
+        { Id: '3' },
+        { Id: '4' },
+        { Id: '5' },
+        { Id: '6' },
+        { Id: '7' },
+        { Id: '8' },
+        { Id: '9' },
+        { Id: '10' },
+        { Id: '11' },
+        { Id: '12' },
+        { Id: '13' },
+        { Id: '14' }
+      ]
     })
     await expect(second).resolves.toEqual({
       numFlushed: 15,
-      results: Array(15).fill({ MessageId: messageId })
+      results: [
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' },
+        { MessageId: messageId, Id: '2' },
+        { MessageId: messageId, Id: '3' },
+        { MessageId: messageId, Id: '4' },
+        { MessageId: messageId, Id: '5' },
+        { MessageId: messageId, Id: '6' },
+        { MessageId: messageId, Id: '7' },
+        { MessageId: messageId, Id: '8' },
+        { MessageId: messageId, Id: '9' },
+        { MessageId: messageId, Id: '10' },
+        { MessageId: messageId, Id: '11' },
+        { MessageId: messageId, Id: '12' },
+        { MessageId: messageId, Id: '13' },
+        { MessageId: messageId, Id: '14' }
+      ]
     })
     expect(sqsMock).toHaveReceivedNthCommandWith(1, GetQueueUrlCommand, { QueueName: qname1 })
     expect(sqsMock).toHaveReceivedNthCommandWith(2, GetQueueUrlCommand, { QueueName: qname2 })
@@ -1370,13 +1641,40 @@ describe('enqueueBatch', () => {
       .resolves({ QueueUrl: qrl })
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
       .resolvesOnce({
-        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '2' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '3' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '4' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '5' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '6' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '7' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '8' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '9' }
+        ]
       })
       .resolvesOnce({
-        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '10' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '11' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '12' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '13' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '14' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '15' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '16' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '17' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '18' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '19' }
+        ]
       })
       .resolvesOnce({
-        Successful: Array(4).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '20' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '21' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '22' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '23' }
+        ]
       })
 
     const pairs = await loadBatchFiles(['test/fixtures/test-unique01-x24.batch'])
@@ -1387,7 +1685,32 @@ describe('enqueueBatch', () => {
 
     await expect(enqueueBatch(pairs, opt)).resolves.toEqual({
       numFlushed: 24,
-      results: Array(24).fill({ MessageId: messageId })
+      results: [
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' },
+        { MessageId: messageId, Id: '2' },
+        { MessageId: messageId, Id: '3' },
+        { MessageId: messageId, Id: '4' },
+        { MessageId: messageId, Id: '5' },
+        { MessageId: messageId, Id: '6' },
+        { MessageId: messageId, Id: '7' },
+        { MessageId: messageId, Id: '8' },
+        { MessageId: messageId, Id: '9' },
+        { MessageId: messageId, Id: '10' },
+        { MessageId: messageId, Id: '11' },
+        { MessageId: messageId, Id: '12' },
+        { MessageId: messageId, Id: '13' },
+        { MessageId: messageId, Id: '14' },
+        { MessageId: messageId, Id: '15' },
+        { MessageId: messageId, Id: '16' },
+        { MessageId: messageId, Id: '17' },
+        { MessageId: messageId, Id: '18' },
+        { MessageId: messageId, Id: '19' },
+        { MessageId: messageId, Id: '20' },
+        { MessageId: messageId, Id: '21' },
+        { MessageId: messageId, Id: '22' },
+        { MessageId: messageId, Id: '23' }
+      ]
     })
 
     expect(sqsMock).toHaveReceivedCommandTimes(GetQueueUrlCommand, 1)

--- a/test/enqueue.test.js
+++ b/test/enqueue.test.js
@@ -759,15 +759,15 @@ describe('addMessage / flushMessages', () => {
     const sendBuffer = {}
 
     // First 9 should not flush
-    expect(addMessage(qrl, cmd, 0, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 1, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 2, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 3, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 4, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 5, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 6, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 7, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 8, options, sendBuffer)).resolves.toBe(0)
+    expect(addMessage(qrl, cmd, 0, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 1, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 2, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 3, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 4, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 5, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 6, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 7, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 8, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
 
     // Now we should see a flush
     setSQSClient(sqsMock)
@@ -796,14 +796,24 @@ describe('addMessage / flushMessages', () => {
       })
 
     // And the next one should flush all 10
-    expect(addMessage(qrl, cmd, 9, options, sendBuffer)).resolves.toBe(10)
+    expect(addMessage(qrl, cmd, 9, options, sendBuffer)).resolves.toEqual({
+      numFlushed: 10,
+      results: Array(10).fill({ MessageId: messageId })
+    })
 
     // And add three more
-    expect(addMessage(qrl, cmd, 10, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 11, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 12, options, sendBuffer)).resolves.toBe(0)
+    expect(addMessage(qrl, cmd, 10, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 11, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 12, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
     // should flush those three
-    await expect(flushMessages(qrl, options, sendBuffer)).resolves.toBe(3)
+    await expect(flushMessages(qrl, options, sendBuffer)).resolves.toEqual({
+      numFlushed: 3,
+      results: [
+        { MessageId: messageId },
+        { MessageId: messageId },
+        { MessageId: messageId }
+      ]
+    })
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(
         1,
@@ -851,15 +861,15 @@ describe('addMessage / flushMessages', () => {
     const sendBuffer = {}
 
     // First 9 should not flush
-    expect(addMessage(qrl, cmd, 0, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 1, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 2, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 3, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 4, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 5, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 6, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 7, options, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 8, options, sendBuffer)).resolves.toBe(0)
+    expect(addMessage(qrl, cmd, 0, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 1, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 2, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 3, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 4, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 5, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 6, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 7, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 8, options, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
 
     // Now we should see a flush
     setSQSClient(sqsMock)
@@ -890,12 +900,15 @@ describe('addMessage / flushMessages', () => {
       })
 
     // And the next one should flush all 10
-    expect(addMessage(qrl, cmd, 9, opt, sendBuffer)).resolves.toBe(10)
+    expect(addMessage(qrl, cmd, 9, opt, sendBuffer)).resolves.toEqual({
+      numFlushed: 10,
+      results: Array(10).fill({ MessageId: messageId })
+    })
 
     // And add three more
-    expect(addMessage(qrl, cmd, 10, opt, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 11, opt, sendBuffer)).resolves.toBe(0)
-    expect(addMessage(qrl, cmd, 12, opt, sendBuffer)).resolves.toBe(0)
+    expect(addMessage(qrl, cmd, 10, opt, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 11, opt, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
+    expect(addMessage(qrl, cmd, 12, opt, sendBuffer)).resolves.toEqual({ numFlushed: 0, results: [] })
     // should flush those three
     await expect(flushMessages(qrl, opt, sendBuffer))
       .rejects.toThrow('One or more message failures')
@@ -1107,7 +1120,13 @@ describe('enqueueBatch', () => {
       })
     await expect(
       enqueueBatch(pairs, opt)
-    ).resolves.toBe(2)
+    ).resolves.toEqual({
+      numFlushed: 2,
+      results: [
+        { MessageId: messageId },
+        { MessageId: messageId }
+      ]
+    })
     expect(sqsMock)
       .toHaveReceivedNthCommandWith(1, GetQueueUrlCommand, { QueueName: qname })
     expect(sqsMock)
@@ -1133,17 +1152,23 @@ describe('enqueueBatch', () => {
       .on(GetQueueUrlCommand, { QueueName: qname })
       .resolves({ QueueUrl: qrl })
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
-      .resolves({
-        Successful: [
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId }
-        ]
+      .resolvesOnce({
+        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+      .resolvesOnce({
+        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+      .resolvesOnce({
+        Successful: Array(4).fill({ MD5OfMessageBody: md5, MessageId: messageId })
       })
 
     const pairs = await loadBatchFiles(['test/fixtures/test-unique01-x24.batch'])
     expect(pairs).toEqual(Array(24).fill({ command: 'true', queue: 'test' }))
 
-    await expect(enqueueBatch(pairs, opt)).resolves.toBe(24)
+    await expect(enqueueBatch(pairs, opt)).resolves.toEqual({
+      numFlushed: 24,
+      results: Array(24).fill({ MessageId: messageId })
+    })
 
     expect(sqsMock).toHaveReceivedCommandTimes(GetQueueUrlCommand, 1)
     expect(sqsMock).toHaveReceivedCommandTimes(SendMessageBatchCommand, 3)
@@ -1162,17 +1187,23 @@ describe('enqueueBatch', () => {
       .on(GetQueueUrlCommand, { QueueName: qname })
       .resolves({ QueueUrl: qrl })
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
-      .resolves({
-        Successful: [
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId }
-        ]
+      .resolvesOnce({
+        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+      .resolvesOnce({
+        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+      .resolvesOnce({
+        Successful: Array(4).fill({ MD5OfMessageBody: md5, MessageId: messageId })
       })
 
     const pairs = await loadBatchFiles(['test/fixtures/test-unique01-x24.batch'])
     expect(pairs).toEqual(Array(24).fill({ command: 'true', queue: 'test' }))
 
-    await expect(enqueueBatch(pairs, opt)).resolves.toBe(24)
+    await expect(enqueueBatch(pairs, opt)).resolves.toEqual({
+      numFlushed: 24,
+      results: Array(24).fill({ MessageId: messageId })
+    })
 
     expect(sqsMock).toHaveReceivedCommandTimes(GetQueueUrlCommand, 1)
     expect(sqsMock).toHaveReceivedCommandTimes(SendMessageBatchCommand, 3)
@@ -1191,17 +1222,23 @@ describe('enqueueBatch', () => {
       .on(GetQueueUrlCommand, { QueueName: qname })
       .resolves({ QueueUrl: qrl })
       .on(SendMessageBatchCommand, { QueueUrl: qrl })
-      .resolves({
-        Successful: [
-          { MD5OfMessageBody: md5, MessageId: messageId },
-          { MD5OfMessageBody: md5, MessageId: messageId }
-        ]
+      .resolvesOnce({
+        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+      .resolvesOnce({
+        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+      .resolvesOnce({
+        Successful: Array(4).fill({ MD5OfMessageBody: md5, MessageId: messageId })
       })
 
     const pairs = await loadBatchFiles(['test/fixtures/test-unique01-x24.batch'])
     expect(pairs).toEqual(Array(24).fill({ command: 'true', queue: 'test' }))
 
-    await expect(enqueueBatch(pairs, opt)).resolves.toBe(24)
+    await expect(enqueueBatch(pairs, opt)).resolves.toEqual({
+      numFlushed: 24,
+      results: Array(24).fill({ MessageId: messageId })
+    })
 
     expect(sqsMock).toHaveReceivedCommandTimes(GetQueueUrlCommand, 1)
     expect(sqsMock).toHaveReceivedCommandTimes(SendMessageBatchCommand, 3)
@@ -1276,8 +1313,14 @@ describe('enqueueBatch', () => {
       })
     const first = enqueueBatch(pairs, opt)
     const second = enqueueBatch(pairs.map(p => ({ queue: qname3, command: cmd })), { ...opt, fifo: true })
-    await expect(first).resolves.toBe(15)
-    await expect(second).resolves.toBe(15)
+    await expect(first).resolves.toEqual({
+      numFlushed: 15,
+      results: Array(15).fill({ MessageId: undefined })
+    })
+    await expect(second).resolves.toEqual({
+      numFlushed: 15,
+      results: Array(15).fill({ MessageId: messageId })
+    })
     expect(sqsMock).toHaveReceivedNthCommandWith(1, GetQueueUrlCommand, { QueueName: qname1 })
     expect(sqsMock).toHaveReceivedNthCommandWith(2, GetQueueUrlCommand, { QueueName: qname2 })
     expect(sqsMock).toHaveReceivedNthCommandWith(3, GetQueueUrlCommand, { QueueName: qname3 })
@@ -1311,5 +1354,43 @@ describe('enqueueBatch', () => {
           { deduplicationId: messageId, groupId: messageId }
         ))
       })
+  })
+
+  test('test/fixtures/test-unique01-x24.batch with individual group-ids', async () => {
+    const messageId = '1e0632f4-b9e8-4f5c-a8e2-3529af1a56d6'
+    const opt = getOptionsWithDefaults({ prefix: '', fifo: true, uuidFunction: () => messageId })
+    const qname = 'test.fifo'
+    const qrl = `https://sqs.us-east-1.amazonaws.com/foobar/${qname}`
+    const md5 = 'foobar'
+
+    const sqsMock = mockClient(client)
+    setSQSClient(sqsMock)
+    sqsMock
+      .on(GetQueueUrlCommand, { QueueName: qname })
+      .resolves({ QueueUrl: qrl })
+      .on(SendMessageBatchCommand, { QueueUrl: qrl })
+      .resolvesOnce({
+        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+      .resolvesOnce({
+        Successful: Array(10).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+      .resolvesOnce({
+        Successful: Array(4).fill({ MD5OfMessageBody: md5, MessageId: messageId })
+      })
+
+    const pairs = await loadBatchFiles(['test/fixtures/test-unique01-x24.batch'])
+    expect(pairs).toEqual(Array(24).fill({ command: 'true', queue: 'test' }))
+    for (const [index, pair] of pairs.entries()) {
+      pair.groupId = index
+    }
+
+    await expect(enqueueBatch(pairs, opt)).resolves.toEqual({
+      numFlushed: 24,
+      results: Array(24).fill({ MessageId: messageId })
+    })
+
+    expect(sqsMock).toHaveReceivedCommandTimes(GetQueueUrlCommand, 1)
+    expect(sqsMock).toHaveReceivedCommandTimes(SendMessageBatchCommand, 3)
   })
 })


### PR DESCRIPTION
Closes suredone/suredone#10368
Closes suredone/suredone#10541

Some callers (internal user) want to reference deduplication ids.

## qa / merge notes

- [x] passes tests
- [x] provide prototype for php side