### PR TITLE
Fix check / Better handle queue name caching

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -103,7 +103,7 @@ export async function checkFailQueue (queue, qrl, opt, indent = '') {
   try {
     // Get fail queue params, creating fail queue if it doesn't exist and create flag is set
     if (opt.verbose) console.error(chalk.blue(indent + 'checking ') + fqname)
-    const { params: { Attributes: desired } } = await getFailParams(queue, opt)
+    const { Attributes: desired } = await getFailParams(queue, opt)
     const { Attributes: current } = await getQueueAttributes(fqrl)
     if (attributesMatch(current, desired, opt, indent + '  ')) {
       if (opt.verbose) console.error(chalk.green(indent + '  all good'))
@@ -128,7 +128,7 @@ export async function checkQueue (queue, qrl, opt, indent = '') {
   if (opt.verbose) console.error(chalk.blue(indent + 'checking ') + qname)
   await checkFailQueue(queue, qrl, opt, indent + '  ')
   try {
-    const { params: { Attributes: desired } } = await getQueueParams(queue, opt)
+    const { Attributes: desired } = await getQueueParams(queue, opt)
     const { Attributes: current, $metadata } = await getQueueAttributes(qrl)
     debug({ current, $metadata })
     if (attributesMatch(current, desired, opt, indent + '  ')) {

--- a/src/enqueue.js
+++ b/src/enqueue.js
@@ -15,6 +15,7 @@ import {
 import {
   qrlCacheGet,
   qrlCacheSet,
+  qrlCacheInvalidate,
   normalizeQueueName,
   normalizeFailQueueName,
   normalizeDLQName
@@ -221,7 +222,7 @@ const retryableExceptions = [
   QueueDoesNotExist // Queue could temporarily not exist due to eventual consistency, let it retry
 ]
 
-export async function sendMessage (qrl, command, opt, messageOptions) {
+export async function sendMessage (qrl, queue, command, opt, messageOptions) {
   debug('sendMessage(', qrl, command, ')')
   const uuidFunction = opt.uuidFunction || uuidV1
   const params = {
@@ -248,6 +249,12 @@ export async function sendMessage (qrl, command, opt, messageOptions) {
   }
   const shouldRetry = async (result, error) => {
     if (!error) return false
+
+    if (error instanceof QueueDoesNotExist) {
+      const qname = normalizeQueueName(queue, opt)
+      qrlCacheInvalidate(qname)
+    }
+
     for (const exceptionClass of retryableExceptions) {
       if (error instanceof exceptionClass) {
         debug({ sendMessageRetryingBecause: { error, result } })
@@ -436,7 +443,7 @@ export async function enqueue (queue, command, options) {
   }
   try {
     const qrl = await getOrCreateQueue(queue, opt)
-    return sendMessage(qrl, command, opt)
+    return sendMessage(qrl, queue, command, opt)
   } catch (e) {
     console.log(e)
     throw e

--- a/src/enqueue.js
+++ b/src/enqueue.js
@@ -253,6 +253,8 @@ export async function sendMessage (qrl, queue, command, opt, messageOptions) {
     if (error instanceof QueueDoesNotExist) {
       const qname = normalizeQueueName(queue, opt)
       qrlCacheInvalidate(qname)
+      // clear cache in case cache does not reflect reality, then try recreating the queue before sending message again
+      await getOrCreateQueue(queue, opt)
     }
 
     for (const exceptionClass of retryableExceptions) {


### PR DESCRIPTION
- [ ] Fix typo with attributes in the check command
- [ ] Validate if this is the correct approach to invalidating the cache upon initial fail
  - Don't like introducing new vars to the function signature, but this way we don't have to wait for exponential backoff to complete before clearing cache
- [ ] Guidance on fixing failing tests