### PR TITLE
Add ApproximateAgeOfOldestMessage to monitor command

### DIFF
--- a/src/cloudWatch.js
+++ b/src/cloudWatch.js
@@ -85,6 +85,16 @@ export async function putAggregateData (total, timestamp) {
         Timestamp: now,
         Value: total.ApproximateNumberOfMessagesNotVisible || 0,
         Unit: 'Count'
+      },
+      {
+        MetricName: 'ApproximateAgeOfOldestMessage',
+        Dimensions: [{
+          Name: 'queueName',
+          Value: total.queueName
+        }],
+        Timestamp: now,
+        Value: total.ApproximateAgeOfOldestMessage || 0,
+        Unit: 'Seconds'
       }
     ]
   }

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -44,8 +44,10 @@ export function interpretWildcard (queueName) {
  *  - ApproximateNumberOfMessages: Sum
  *  - ApproximateNumberOfMessagesDelayed: Sum
  *  - ApproximateNumberOfMessagesNotVisible: Sum
+ *  - ApproximateAgeOfOldestMessage: Max
  */
 export async function getAggregateData (queueName) {
+  const maxAttributes = new Set(['ApproximateAgeOfOldestMessage'])
   const { prefix, suffixRegex } = interpretWildcard(queueName)
   const qrls = await getMatchingQueues(prefix, suffixRegex)
   // debug({ qrls })
@@ -59,7 +61,11 @@ export async function getAggregateData (queueName) {
       const newAtrribute = parseInt(result.Attributes[key], 10)
       if (newAtrribute > 0) {
         total.contributingQueueNames.add(queue)
-        total[key] = (total[key] || 0) + newAtrribute
+        if (maxAttributes.has(key)) {
+          total[key] = Math.max(total[key] || 0, newAtrribute)
+        } else {
+          total[key] = (total[key] || 0) + newAtrribute
+        }
       }
     }
   }

--- a/src/sqs.js
+++ b/src/sqs.js
@@ -55,7 +55,8 @@ export async function getQueueAttributes (qrls) {
       AttributeNames: [
         'ApproximateNumberOfMessages',
         'ApproximateNumberOfMessagesNotVisible',
-        'ApproximateNumberOfMessagesDelayed'
+        'ApproximateNumberOfMessagesDelayed',
+        'ApproximateAgeOfOldestMessage'
       ]
     }
     const command = new GetQueueAttributesCommand(input)
@@ -76,7 +77,8 @@ export async function getQueueAttributes (qrls) {
             Attributes: {
               ApproximateNumberOfMessages: '0',
               ApproximateNumberOfMessagesNotVisible: '0',
-              ApproximateNumberOfMessagesDelayed: '0'
+              ApproximateNumberOfMessagesDelayed: '0',
+              ApproximateAgeOfOldestMessage: '0'
             }
           }
         }

--- a/test/cloudWatch.test.js
+++ b/test/cloudWatch.test.js
@@ -29,7 +29,8 @@ describe('putData', () => {
       contributingQueueNames: ['one', 'two', 'three'],
       ApproximateNumberOfMessages: 100,
       ApproximateNumberOfMessagesDelayed: 11,
-      ApproximateNumberOfMessagesNotVisible: 2
+      ApproximateNumberOfMessagesNotVisible: 2,
+      ApproximateAgeOfOldestMessage: 450
     }
     const now = new Date()
     await expect(putAggregateData(data, now)).resolves.toEqual()
@@ -38,6 +39,7 @@ describe('putData', () => {
     delete data.ApproximateNumberOfMessages
     delete data.ApproximateNumberOfMessagesDelayed
     delete data.ApproximateNumberOfMessagesNotVisible
+    delete data.ApproximateAgeOfOldestMessage
     await expect(putAggregateData(data, now)).resolves.toEqual()
     expect(cwMock)
       .toHaveReceivedNthSpecificCommandWith(1, PutMetricDataCommand, {
@@ -77,6 +79,13 @@ describe('putData', () => {
             Timestamp: now,
             Value: 2,
             Unit: 'Count'
+          },
+          {
+            MetricName: 'ApproximateAgeOfOldestMessage',
+            Dimensions: [{ Name: 'queueName', Value: queueName }],
+            Timestamp: now,
+            Value: 450,
+            Unit: 'Seconds'
           }
         ]
       })
@@ -118,6 +127,13 @@ describe('putData', () => {
             Timestamp: now,
             Value: 0,
             Unit: 'Count'
+          },
+          {
+            MetricName: 'ApproximateAgeOfOldestMessage',
+            Dimensions: [{ Name: 'queueName', Value: queueName }],
+            Timestamp: now,
+            Value: 0,
+            Unit: 'Seconds'
           }
         ]
       })

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -77,19 +77,22 @@ describe('getAggregateData', () => {
       .resolvesOnce({
         Attributes: {
           ApproximateNumberOfMessages: 10,
-          ApproximateNumberOfMessagesDelayed: 1
+          ApproximateNumberOfMessagesDelayed: 1,
+          ApproximateAgeOfOldestMessage: 300
         }
       })
       .resolvesOnce({
         Attributes: {
           ApproximateNumberOfMessages: 11,
-          ApproximateNumberOfMessagesNotVisible: 0
+          ApproximateNumberOfMessagesNotVisible: 0,
+          ApproximateAgeOfOldestMessage: 600
         }
       })
       .resolvesOnce({
         Attributes: {
           ApproximateNumberOfMessagesDelayed: 2,
-          ApproximateNumberOfMessagesNotVisible: 2
+          ApproximateNumberOfMessagesNotVisible: 2,
+          ApproximateAgeOfOldestMessage: 150
         }
       })
     const queueName = 'sdqd_amzn_orders_*_failed'
@@ -105,7 +108,8 @@ describe('getAggregateData', () => {
       ],
       ApproximateNumberOfMessages: 21,
       ApproximateNumberOfMessagesDelayed: 3,
-      ApproximateNumberOfMessagesNotVisible: 2
+      ApproximateNumberOfMessagesNotVisible: 2,
+      ApproximateAgeOfOldestMessage: 600
     })
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(1, ListQueuesCommand, {
@@ -115,12 +119,12 @@ describe('getAggregateData', () => {
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(1, GetQueueAttributesCommand, {
         QueueUrl: 'https://sqs.us-east-1.amazonaws.com/foobar/sdqd_amzn_orders_0_1021_failed',
-        AttributeNames: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessagesDelayed']
+        AttributeNames: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessagesDelayed', 'ApproximateAgeOfOldestMessage']
       })
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(2, GetQueueAttributesCommand, {
         QueueUrl: 'https://sqs.us-east-1.amazonaws.com/foobar/sdqd_amzn_orders_0_1022_failed',
-        AttributeNames: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessagesDelayed']
+        AttributeNames: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessagesDelayed', 'ApproximateAgeOfOldestMessage']
       })
   })
 })

--- a/test/sqs.test.js
+++ b/test/sqs.test.js
@@ -154,12 +154,12 @@ describe('getQueueAttributes', () => {
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(1, GetQueueAttributesCommand, {
         QueueUrl: 'https://sqs.us-east-1.amazonaws.com/foobar/sdqd_amzn_orders_1_1021_failed',
-        AttributeNames: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessagesDelayed']
+        AttributeNames: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessagesDelayed', 'ApproximateAgeOfOldestMessage']
       })
     expect(sqsMock)
       .toHaveReceivedNthSpecificCommandWith(2, GetQueueAttributesCommand, {
         QueueUrl: 'https://sqs.us-east-1.amazonaws.com/foobar/sdqd_amzn_orders_1_1022_failed',
-        AttributeNames: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessagesDelayed']
+        AttributeNames: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessagesDelayed', 'ApproximateAgeOfOldestMessage']
       })
   })
 })


### PR DESCRIPTION
## Summary
- Read `ApproximateAgeOfOldestMessage` from the existing `GetQueueAttributes` response
- Track the **max** value across all matching queues (worst-case wait time)
- Publish it to CloudWatch alongside existing metrics in the `qmonitor` namespace with `Seconds` unit

## Test plan
- [x] Existing monitor tests updated with age data — verifies max aggregation (300, 600, 150 → 600)
- [x] CloudWatch test updated — verifies metric published with correct value and `Seconds` unit
- [x] SQS test updated — verifies new attribute requested in `GetQueueAttributes` call
- [x] All 161 tests pass

Closes #82