### PR TITLE
Fix FIFO serial-execution using wrong SQS attribute name

### DIFF
--- a/src/scheduler/jobExecutor.js
+++ b/src/scheduler/jobExecutor.js
@@ -389,7 +389,7 @@ export class JobExecutor {
     for (const [job, i] of jobs.map((job, i) => [job, i])) {
       // Figure out if the next job needs to happen in serial, otherwise we can parallel execute
       const nextJob = jobs[i + 1]
-      const nextJobIsSerial = isFifo && nextJob && job.message?.Attributes?.GroupId === nextJob.message?.Attributes?.GroupId
+      const nextJobIsSerial = isFifo && nextJob && job.message?.Attributes?.MessageGroupId === nextJob.message?.Attributes?.MessageGroupId
 
       // console.log({ i, nextJobAtt: nextJob?.message?.Attributes, nextJobIsSerial })
       // Execute serial or parallel


### PR DESCRIPTION
## Summary
- Fixed `Attributes?.GroupId` → `Attributes?.MessageGroupId` in FIFO serial-execution logic (`jobExecutor.js:392`)
- `GroupId` doesn't exist in the SQS API — the correct system attribute is `MessageGroupId` ([AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html))
- The same file already uses `MessageGroupId` correctly on line 331, and `worker.js:115` uses it correctly too — this was the only incorrect reference

## Impact
Previously, `Attributes?.GroupId` was always `undefined`, so the comparison `undefined === undefined` was always `true`. This forced **all** FIFO messages in a batch to execute serially, even when they belonged to different message groups that could safely run in parallel.

After this fix, only messages in the **same** message group execute serially, while messages in different groups correctly execute in parallel.

## Test plan
- [x] Verified AWS SQS docs confirm attribute name is `MessageGroupId`
- [x] Confirmed rest of codebase already uses `MessageGroupId` correctly
- [ ] Existing tests pass (`npm test`)

Fixes #87