### PR TITLE
Fix validateMessageOptions rejecting per-message delay

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -66,7 +66,7 @@ export function validateQueueName (opt, name) {
 }
 
 export function validateMessageOptions (messageOptions) {
-  const validKeys = ['deduplicationId', 'groupId']
+  const validKeys = ['deduplicationId', 'groupId', 'delay']
   if (typeof messageOptions === 'object' &&
       !Array.isArray(messageOptions) &&
       messageOptions !== null) {

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -55,6 +55,12 @@ describe('validateMessageOptions', () => {
     expect(validateMessageOptions({ deduplicationId: 1 })).toEqual({ deduplicationId: 1 })
     expect(validateMessageOptions({ groupId: 1, deduplicationId: 1 })).toEqual({ groupId: 1, deduplicationId: 1 })
   })
+  test('delay is a valid message option', () => {
+    expect(validateMessageOptions({ delay: 15 })).toEqual({ delay: 15 })
+    expect(validateMessageOptions({ delay: 0 })).toEqual({ delay: 0 })
+    expect(validateMessageOptions({ delay: 15, groupId: 'g1' })).toEqual({ delay: 15, groupId: 'g1' })
+    expect(validateMessageOptions({ delay: 15, groupId: 'g1', deduplicationId: 'd1' })).toEqual({ delay: 15, groupId: 'g1', deduplicationId: 'd1' })
+  })
 })
 
 describe('getOptionsWithDefaults', () => {

--- a/test/enqueue.test.js
+++ b/test/enqueue.test.js
@@ -472,6 +472,16 @@ describe('formatMessage', () => {
     const id = '1234'
     expect(formatMessage(cmd, id, opt)).toEqual({ MessageBody: cmd, Id: id })
   })
+  test('per-message delay sets DelaySeconds', async () => {
+    const opt = getOptionsWithDefaults()
+    const cmd = 'sd BulkStatusModel finalizeAll'
+    expect(formatMessage(cmd, '0', opt, { delay: 30 })).toEqual({ MessageBody: cmd, Id: '0', DelaySeconds: 30 })
+  })
+  test('per-message delay overrides global delay', async () => {
+    const opt = getOptionsWithDefaults({ delay: 10 })
+    const cmd = 'sd BulkStatusModel finalizeAll'
+    expect(formatMessage(cmd, '0', opt, { delay: 30 })).toEqual({ MessageBody: cmd, Id: '0', DelaySeconds: 30 })
+  })
 })
 
 describe('sendMessage', () => {
@@ -1279,6 +1289,50 @@ describe('enqueueBatch', () => {
         Entries: [
           { MessageBody: cmd, Id: '0' },
           { MessageBody: cmd, Id: '1' }
+        ]
+      })
+  })
+
+  test('enqueueBatch with per-message delay works', async () => {
+    const messageId = '1e0632f4-b9e8-4f5c-a8e2-3529af1a56d6'
+    const opt = getOptionsWithDefaults({ prefix: '', uuidFunction: () => messageId })
+    const qname = 'testqueue'
+    const qrl = `https://sqs.us-east-1.amazonaws.com/foobar/${qname}`
+    const cmd = 'sd BulkStatusModel finalizeAll'
+    const sqsMock = mockClient(client)
+    const md5 = 'foobar'
+    const pairs = [
+      { queue: qname, command: cmd, messageOptions: { delay: 30 } },
+      { queue: qname, command: cmd, messageOptions: { delay: 60 } }
+    ]
+    setSQSClient(sqsMock)
+    sqsMock
+      .on(GetQueueUrlCommand, { QueueName: qname })
+      .resolves({ QueueUrl: qrl })
+      .on(SendMessageBatchCommand, { QueueUrl: qrl })
+      .resolves({
+        Successful: [
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '0' },
+          { MD5OfMessageBody: md5, MessageId: messageId, Id: '1' }
+        ]
+      })
+    await expect(
+      enqueueBatch(pairs, opt)
+    ).resolves.toEqual({
+      numFlushed: 2,
+      results: [
+        { MessageId: messageId, Id: '0' },
+        { MessageId: messageId, Id: '1' }
+      ]
+    })
+    expect(sqsMock)
+      .toHaveReceivedNthCommandWith(1, GetQueueUrlCommand, { QueueName: qname })
+    expect(sqsMock)
+      .toHaveReceivedNthCommandWith(2, SendMessageBatchCommand, {
+        QueueUrl: qrl,
+        Entries: [
+          { MessageBody: cmd, Id: '0', DelaySeconds: 30 },
+          { MessageBody: cmd, Id: '1', DelaySeconds: 60 }
         ]
       })
   })


### PR DESCRIPTION
## Summary

- Add `delay` to the `validKeys` array in `validateMessageOptions()` so per-message `DelaySeconds` works in `enqueueBatch()`
- `formatMessage()` already supports `messageOptions.delay` but validation was throwing `"Invalid message option delay"` before it could be applied
- This has caused 2,527 Sentry occurrences (NODE-CLI-1X7) since 2025-04-23, silently breaking automation batch throttling in production

## Test plan

- [x] New unit test: `validateMessageOptions` accepts `delay` alone and combined with other valid keys
- [x] New unit test: `formatMessage` sets `DelaySeconds` from per-message delay
- [x] New unit test: `formatMessage` per-message delay overrides global delay
- [x] New integration test: `enqueueBatch` with per-message `delay` sends correct `DelaySeconds` per entry
- [x] All 174 existing tests continue to pass

Closes #84