### PR TITLE
Allow inline jobs to opt out of kill-after enforcement

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "qdone",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qdone",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "3.465.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qdone",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "A distributed scheduler for SQS",
   "type": "module",
   "main": "./index.js",

--- a/src/scheduler/jobExecutor.js
+++ b/src/scheduler/jobExecutor.js
@@ -188,8 +188,7 @@ export class JobExecutor {
 
     job.executionMode = 'inline'
     job.killDue = false
-    clearTimeout(job.killTimer)
-    clearTimeout(job.killSignalTimer)
+    this.clearJobTimers(job)
 
     if (job.status === 'running' && job.visibilityTimeout < defaultVisibilityTimeout) {
       await this.setJobVisibilityTimeout(job, defaultVisibilityTimeout)
@@ -508,6 +507,10 @@ export class JobExecutor {
         messageGroupId: job.message.Attributes?.MessageGroupId || '',
         /** Call with a child process PID to enable kill-after process termination. */
         registerPid: (pid) => {
+          if (job.executionMode === 'inline') {
+            debug('registerPid ignored after registerInlineExecution', { messageId: job.message?.MessageId })
+            return
+          }
           if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 1 || pid === process.pid) {
             debug('registerPid: rejected invalid PID', pid)
             return

--- a/src/scheduler/jobExecutor.js
+++ b/src/scheduler/jobExecutor.js
@@ -98,7 +98,7 @@ export class JobExecutor {
   killJob (job, start = new Date()) {
     if (!job.executionStart || job.status !== 'running') return
     if (job.killed) return
-    if (job.executionMode === 'inline') return
+    if (!this.shouldEnforceKillAfter(job)) return
 
     const executionTimeMs = this.getExecutionTimeMs(job, start)
     if (executionTimeMs < this.opt.killAfter * 1000) return
@@ -238,7 +238,6 @@ export class JobExecutor {
       this.maintainPromise = this.maintainVisibility()
     }, nextCheckInMs)
 
-    // debug('maintainVisibility', this.jobs)
     const start = new Date()
     const jobsToExtendByQrl = {}
     const jobsToDeleteByQrl = {}
@@ -250,7 +249,6 @@ export class JobExecutor {
       const job = this.jobs[i]
       const jobRunTime = Math.round((start - job.start) / 1000)
       jobStatuses[job.status] = (jobStatuses[job.status] || 0) + 1
-      // debug('considering job', job)
       if (job.status === 'complete') {
         const jobsToDelete = jobsToDeleteByQrl[job.qrl] || []
         job.status = 'deleting'
@@ -579,15 +577,12 @@ export class JobExecutor {
     const isFifo = qrl.endsWith('.fifo')
     const runningJobs = []
 
-    // console.log(jobs)
-
     // Begin executing
     for (const [job, i] of jobs.map((job, i) => [job, i])) {
       // Figure out if the next job needs to happen in serial, otherwise we can parallel execute
       const nextJob = jobs[i + 1]
       const nextJobIsSerial = isFifo && nextJob && job.message?.Attributes?.MessageGroupId === nextJob.message?.Attributes?.MessageGroupId
 
-      // console.log({ i, nextJobAtt: nextJob?.message?.Attributes, nextJobIsSerial })
       // Execute serial or parallel
       if (nextJobIsSerial) await this.runJob(job)
       else runningJobs.push(this.runJob(job))

--- a/src/scheduler/jobExecutor.js
+++ b/src/scheduler/jobExecutor.js
@@ -81,6 +81,10 @@ export class JobExecutor {
     return start - job.executionStart
   }
 
+  shouldEnforceKillAfter (job) {
+    return !!(this.opt.killAfter && job.executionMode !== 'inline')
+  }
+
   scheduleKillAfter (job) {
     if (!this.opt.killAfter) return
     clearTimeout(job.killTimer)
@@ -94,6 +98,7 @@ export class JobExecutor {
   killJob (job, start = new Date()) {
     if (!job.executionStart || job.status !== 'running') return
     if (job.killed) return
+    if (job.executionMode === 'inline') return
 
     const executionTimeMs = this.getExecutionTimeMs(job, start)
     if (executionTimeMs < this.opt.killAfter * 1000) return
@@ -140,14 +145,10 @@ export class JobExecutor {
     job.killSignalTimer.unref?.()
   }
 
-  async setRunningVisibilityTimeout (job) {
-    if (!this.opt.killAfter) return
-
-    const visibilityTimeout = Math.max(1, Math.min(job.visibilityTimeout, this.opt.killAfter))
-    if (visibilityTimeout >= job.visibilityTimeout) return
-
+  async setJobVisibilityTimeout (job, visibilityTimeout, start = new Date()) {
     job.visibilityTimeout = visibilityTimeout
-    job.extendAtSecond = Math.round(job.visibilityTimeout / 2)
+    const jobRunTime = Math.round((start - job.start) / 1000)
+    job.extendAtSecond = Math.round(jobRunTime + job.visibilityTimeout / 2)
 
     const input = {
       QueueUrl: job.qrl,
@@ -166,6 +167,56 @@ export class JobExecutor {
       if (this.opt.verbose) {
         console.error(chalk.red('FAILED_TO_SET_VISIBILITY_TIMEOUT'), { err, input })
       }
+    }
+  }
+
+  async setRunningVisibilityTimeout (job) {
+    if (!this.shouldEnforceKillAfter(job)) return
+
+    const visibilityTimeout = Math.max(1, Math.min(job.visibilityTimeout, this.opt.killAfter))
+    if (visibilityTimeout >= job.visibilityTimeout) return
+
+    await this.setJobVisibilityTimeout(job, visibilityTimeout)
+  }
+
+  async registerInlineExecution (job) {
+    if (job.executionMode === 'inline') return
+    if (job.executionMode === 'child_process') {
+      debug('registerInlineExecution ignored after registerPid', { messageId: job.message?.MessageId })
+      return
+    }
+
+    job.executionMode = 'inline'
+    job.killDue = false
+    clearTimeout(job.killTimer)
+    clearTimeout(job.killSignalTimer)
+
+    if (job.status === 'running' && job.visibilityTimeout < defaultVisibilityTimeout) {
+      await this.setJobVisibilityTimeout(job, defaultVisibilityTimeout)
+    }
+  }
+
+  logInlineKillAfterOverrun (job, start = new Date()) {
+    if (!this.opt.killAfter || !job.executionStart || job.inlineKillAfterLogged) return
+
+    const executionTimeMs = this.getExecutionTimeMs(job, start)
+    if (executionTimeMs < this.opt.killAfter * 1000) return
+
+    job.inlineKillAfterLogged = true
+    const executionTime = Math.floor(executionTimeMs / 1000)
+    if (this.opt.verbose) {
+      console.error(chalk.yellow('INLINE_JOB_EXCEEDED_KILL_AFTER'), job.prettyQname,
+        chalk.yellow('after'), executionTime, chalk.yellow('seconds (limit:'), this.opt.killAfter + ')')
+    } else if (!this.opt.disableLog) {
+      console.log(JSON.stringify({
+        event: 'INLINE_JOB_EXCEEDED_KILL_AFTER',
+        timestamp: start,
+        queue: job.qname,
+        messageId: job.message.MessageId,
+        executionTime,
+        killAfter: this.opt.killAfter,
+        payload: job.payload
+      }))
     }
   }
 
@@ -215,12 +266,14 @@ export class JobExecutor {
         // Kill-after enforcement: terminate child process if it exceeds the deadline.
         // Uses executionStart (when runJob began) so FIFO serial jobs aren't
         // penalized for queue wait time.
-        if (this.opt.killAfter && job.executionStart && !job.killed) {
+        if (this.shouldEnforceKillAfter(job) && job.executionStart && !job.killed) {
           const executionTimeMs = this.getExecutionTimeMs(job, start)
           if (executionTimeMs >= this.opt.killAfter * 1000) {
             job.killDue = true
             this.killJob(job, start)
           }
+        } else if (job.executionMode === 'inline') {
+          this.logInlineKillAfterOverrun(job, start)
         }
 
         if (jobRunTime >= job.extendAtSecond) {
@@ -235,7 +288,7 @@ export class JobExecutor {
           const doubled = job.visibilityTimeout * 2
           const secondsUntilMax = Math.max(1, maxJobSeconds - jobRunTime)
           const executionTimeMs = job.executionStart ? this.getExecutionTimeMs(job, start) : 0
-          const secondsUntilKill = (this.opt.killAfter && job.executionStart)
+          const secondsUntilKill = (this.shouldEnforceKillAfter(job) && job.executionStart)
             ? Math.max(1, Math.ceil((this.opt.killAfter * 1000 - executionTimeMs) / 1000))
             : Infinity
           job.visibilityTimeout = Math.min(doubled, secondsUntilMax, secondsUntilKill)
@@ -459,8 +512,13 @@ export class JobExecutor {
             debug('registerPid: rejected invalid PID', pid)
             return
           }
+          job.executionMode = 'child_process'
           job.pid = pid
           if (job.killDue && !job.killed) this.killJob(job, new Date())
+        },
+        /** Call before inline work starts to opt out of kill-after visibility expiry. */
+        registerInlineExecution: async () => {
+          await this.registerInlineExecution(job)
         }
       }
       const result = await job.callback(queue, job.payload, attributes)

--- a/test/jobExecutor.test.js
+++ b/test/jobExecutor.test.js
@@ -173,6 +173,39 @@ describe('JobExecutor kill-after', () => {
     expect(job.visibilityTimeout).toBe(1)
   })
 
+  test('registerInlineExecution restores default visibility for inline jobs', async () => {
+    const executor = makeExecutor({ killAfter: 30 })
+    const msg = makeMessage('inline-restore')
+    const job = executor.addJob(msg, async (_queue, _payload, attributes) => {
+      await attributes.registerInlineExecution()
+    }, 'sdqd_testqueue', 'https://sqs/sdqd_testqueue')
+
+    await executor.runJob(job)
+
+    expect(job.executionMode).toBe('inline')
+    expect(job.visibilityTimeout).toBe(120)
+    expect(sqsMock).toHaveReceivedCommandTimes(ChangeMessageVisibilityCommand, 2)
+    expect(sqsMock.commandCalls(ChangeMessageVisibilityCommand).map(call => call.args[0].input.VisibilityTimeout)).toEqual([30, 120])
+  })
+
+  test('inline jobs exceeding killAfter are not visibility capped or killed', async () => {
+    const executor = makeExecutor({ killAfter: 60 })
+    const msg = makeMessage('inline-overrun')
+    const job = executor.addJob(msg, async () => {}, 'sdqd_testqueue', 'https://sqs/sdqd_testqueue')
+
+    job.status = 'running'
+    job.executionStart = new Date(Date.now() - 90000)
+    job.executionMode = 'inline'
+    job.extendAtSecond = 0
+
+    await executor.maintainVisibility()
+
+    expect(job.visibilityTimeout).toBe(240)
+    expect(job.killed).toBeUndefined()
+    expect(executor.stats.jobsKilled).toBe(0)
+    expect(job.inlineKillAfterLogged).toBe(true)
+  })
+
   test('job completing within killAfter is not affected', async () => {
     const executor = makeExecutor({ killAfter: 3600 })
     const msg = makeMessage('ok-test')

--- a/test/jobExecutor.test.js
+++ b/test/jobExecutor.test.js
@@ -255,6 +255,35 @@ describe('JobExecutor kill-after', () => {
     expect(job.inlineKillAfterLogged).toBe(true)
   })
 
+  test('registerPid after killDue triggers immediate kill', async () => {
+    jest.useFakeTimers()
+    const killTree = jest.fn((_pid, _signal, callback) => callback?.())
+    const executor = makeExecutor({ killAfter: 1, killTree })
+
+    const promise = executor.executeJobs(
+      [makeMessage('late-pid')],
+      async (_queue, _payload, attributes) => {
+        // Delay PID registration until after the kill deadline
+        await new Promise(resolve => setTimeout(resolve, 1500))
+        attributes.registerPid(54321)
+      },
+      'sdqd_testqueue',
+      'https://sqs/sdqd_testqueue'
+    )
+
+    // Advance past the killAfter deadline — killDue set, but no PID yet
+    await jest.advanceTimersByTimeAsync(1000)
+    expect(killTree).not.toHaveBeenCalled()
+
+    // Advance to where the callback registers the PID — should kill immediately
+    await jest.advanceTimersByTimeAsync(500)
+    expect(killTree).toHaveBeenCalledWith(54321, 'SIGTERM', expect.any(Function))
+    expect(executor.stats.jobsKilled).toBe(1)
+
+    await jest.advanceTimersByTimeAsync(5000)
+    await promise
+  })
+
   test('job completing within killAfter is not affected', async () => {
     const executor = makeExecutor({ killAfter: 3600 })
     const msg = makeMessage('ok-test')

--- a/test/jobExecutor.test.js
+++ b/test/jobExecutor.test.js
@@ -188,6 +188,55 @@ describe('JobExecutor kill-after', () => {
     expect(sqsMock.commandCalls(ChangeMessageVisibilityCommand).map(call => call.args[0].input.VisibilityTimeout)).toEqual([30, 120])
   })
 
+  test('registerInlineExecution is ignored after registerPid', async () => {
+    const executor = makeExecutor({ killAfter: 30 })
+    const msg = makeMessage('pid-first')
+    const job = executor.addJob(msg, async (_queue, _payload, attributes) => {
+      attributes.registerPid(12345)
+      await attributes.registerInlineExecution()
+    }, 'sdqd_testqueue', 'https://sqs/sdqd_testqueue')
+
+    await executor.runJob(job)
+
+    expect(job.executionMode).toBe('child_process')
+    expect(job.pid).toBe(12345)
+    expect(job.visibilityTimeout).toBe(30)
+    expect(sqsMock).toHaveReceivedCommandTimes(ChangeMessageVisibilityCommand, 1)
+  })
+
+  test('registerPid is ignored after registerInlineExecution', async () => {
+    const executor = makeExecutor({ killAfter: 30 })
+    const msg = makeMessage('inline-first')
+    const job = executor.addJob(msg, async (_queue, _payload, attributes) => {
+      await attributes.registerInlineExecution()
+      attributes.registerPid(12345)
+    }, 'sdqd_testqueue', 'https://sqs/sdqd_testqueue')
+
+    await executor.runJob(job)
+
+    expect(job.executionMode).toBe('inline')
+    expect(job.pid).toBeUndefined()
+    expect(job.visibilityTimeout).toBe(120)
+    expect(sqsMock).toHaveReceivedCommandTimes(ChangeMessageVisibilityCommand, 2)
+    expect(sqsMock.commandCalls(ChangeMessageVisibilityCommand).map(call => call.args[0].input.VisibilityTimeout)).toEqual([30, 120])
+  })
+
+  test('registerInlineExecution is idempotent', async () => {
+    const executor = makeExecutor({ killAfter: 30 })
+    const msg = makeMessage('inline-idempotent')
+    const job = executor.addJob(msg, async (_queue, _payload, attributes) => {
+      await attributes.registerInlineExecution()
+      await attributes.registerInlineExecution()
+    }, 'sdqd_testqueue', 'https://sqs/sdqd_testqueue')
+
+    await executor.runJob(job)
+
+    expect(job.executionMode).toBe('inline')
+    expect(job.visibilityTimeout).toBe(120)
+    expect(sqsMock).toHaveReceivedCommandTimes(ChangeMessageVisibilityCommand, 2)
+    expect(sqsMock.commandCalls(ChangeMessageVisibilityCommand).map(call => call.args[0].input.VisibilityTimeout)).toEqual([30, 120])
+  })
+
   test('inline jobs exceeding killAfter are not visibility capped or killed', async () => {
     const executor = makeExecutor({ killAfter: 60 })
     const msg = makeMessage('inline-overrun')


### PR DESCRIPTION
## Summary
- add a callback path for jobs that intentionally execute inline so qdone does not cap visibility to `--kill-after`
- keep PID-based kill-after behavior for true child-process jobs
- bump qdone to `2.2.6` and refresh `npm-shrinkwrap.json` for release prep

## Testing
- pnpm test
- pnpm exec standard
- pnpm run prep-for-publish