### PR TITLE
fix(consumer): release receive accounting on every path; add SQS timeouts

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-cloudwatch": "3.465.0",
         "@aws-sdk/client-sqs": "3.465.0",
         "@sentry/node": "^7.120.4",
+        "@smithy/node-http-handler": "2.5.0",
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.1",
         "command-line-commands": "^3.0.2",
@@ -17579,6 +17580,10 @@
     },
     "node_modules/@sentry/node": {
       "resolved": "node_modules/.pnpm/@sentry+node@7.120.4/node_modules/@sentry/node",
+      "link": true
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "resolved": "node_modules/.pnpm/@smithy+node-http-handler@2.5.0/node_modules/@smithy/node-http-handler",
       "link": true
     },
     "node_modules/aws-sdk-client-mock": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@aws-sdk/client-cloudwatch": "3.465.0",
     "@aws-sdk/client-sqs": "3.465.0",
     "@sentry/node": "^7.120.4",
+    "@smithy/node-http-handler": "2.5.0",
     "chalk": "^4.1.2",
     "command-line-args": "^5.2.1",
     "command-line-commands": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@sentry/node':
         specifier: ^7.120.4
         version: 7.120.4
+      '@smithy/node-http-handler':
+        specifier: 2.5.0
+        version: 2.5.0
       chalk:
         specifier: ^4.1.2
         version: 4.1.2

--- a/src/consumer.js
+++ b/src/consumer.js
@@ -99,6 +99,10 @@ export async function processMessages (queues, callback, options) {
     listeningQrls.add(qrl)
     try {
       const messages = await getMessages(qrl, opt, maxMessages)
+      // Successful receive: release the queue immediately so the scheduler can
+      // issue another receive on it while this batch executes (receive/execute
+      // overlap); the finally below stays as the error-path safety net.
+      listeningQrls.delete(qrl)
 
       if (!shutdownRequested) {
         if (messages.length) {

--- a/src/consumer.js
+++ b/src/consumer.js
@@ -90,11 +90,15 @@ export async function processMessages (queues, callback, options) {
     if (opt.verbose) {
       console.error(chalk.blue('Listening on: '), qname)
     }
+    // Reserve concurrency and mark the queue as in-flight up front, then release
+    // both in the finally so no receive-error path (including a hung socket) can
+    // leak them. A leaked reservation eventually pins allowedJobs to 0, and a
+    // leaked listeningQrls entry makes the queue permanently unpollable — either
+    // way the worker goes silently deaf while the process still looks healthy.
     maxReturnCount += maxMessages
+    listeningQrls.add(qrl)
     try {
-      listeningQrls.add(qrl)
       const messages = await getMessages(qrl, opt, maxMessages)
-      listeningQrls.delete(qrl)
 
       if (!shutdownRequested) {
         if (messages.length) {
@@ -109,16 +113,27 @@ export async function processMessages (queues, callback, options) {
           queueManager.updateIcehouse(qrl, true)
         }
       }
-
-      // Max job accounting
-      maxReturnCount -= maxMessages
     } catch (e) {
-      // If the queue has been cleaned up, we should back off anyway
-      if (e instanceof QueueDoesNotExist) {
-        queueManager.updateIcehouse(qrl, true)
-      } else {
-        throw e
+      // Treat any receive/execute error like an empty receive: back the queue
+      // off through the icehouse and swallow it. listen() is called
+      // fire-and-forget, so rethrowing surfaces as an unhandled rejection (which
+      // a lenient global handler may not even crash on). QueueDoesNotExist is an
+      // expected, benign result of idle-queue GC, so it stays quiet.
+      queueManager.updateIcehouse(qrl, true)
+      if (!(e instanceof QueueDoesNotExist) && !opt.disableLog) {
+        console.log(JSON.stringify({
+          event: 'RECEIVE_ERROR',
+          timestamp: new Date(),
+          queue: qname,
+          qrl,
+          errorName: e?.name,
+          errorMessage: e?.message
+        }))
       }
+    } finally {
+      // Always release the accounting, whatever happened above.
+      listeningQrls.delete(qrl)
+      maxReturnCount -= maxMessages
     }
   }
 
@@ -166,7 +181,9 @@ export async function processMessages (queues, callback, options) {
       if (jobsLeft <= 0) break
       if (listeningQrls.has(qrl)) continue
       const maxMessages = Math.min(10, jobsLeft)
-      listen(qname, qrl, maxMessages)
+      // listen() is guaranteed not to throw, but keep a defensive catch so a
+      // future regression can never turn this fire-and-forget into a crash.
+      listen(qname, qrl, maxMessages).catch(e => debug('unexpected listen rejection', e))
       jobsLeft -= maxMessages
       // debug({ listenedTo: { qname, maxMessages, jobsLeft } })
     }

--- a/src/scheduler/jobExecutor.js
+++ b/src/scheduler/jobExecutor.js
@@ -333,7 +333,28 @@ export class JobExecutor {
         // Change batch
         const input = { QueueUrl: qrl, Entries: entries }
         debug({ ChangeMessageVisibilityBatch: input })
-        const result = await getSQSClient().send(new ChangeMessageVisibilityBatchCommand(input))
+        let result
+        try {
+          result = await getSQSClient().send(new ChangeMessageVisibilityBatchCommand(input))
+        } catch (err) {
+          // A single batch failure must not abort the whole maintenance run and
+          // strand the remaining queues (or the end-of-pass cleanup). Log and
+          // move on; jobs we couldn't extend get re-evaluated next cycle.
+          debug('ChangeMessageVisibilityBatch error', err)
+          if (this.opt.verbose) {
+            console.error(chalk.red('FAILED_TO_EXTEND_BATCH'), { qrl, error: err?.message })
+          } else if (!this.opt.disableLog) {
+            console.log(JSON.stringify({
+              event: 'EXTEND_VISIBILITY_ERROR',
+              timestamp: start,
+              qrl,
+              count: entries.length,
+              errorName: err?.name,
+              errorMessage: err?.message
+            }))
+          }
+          continue
+        }
         debug('ChangeMessageVisibilityBatch returned', result)
         this.stats.sqsCalls++
         if (result.Failed?.length) {
@@ -378,7 +399,28 @@ export class JobExecutor {
         // Delete batch
         const input = { QueueUrl: qrl, Entries: entries }
         debug({ DeleteMessageBatch: input })
-        const result = await getSQSClient().send(new DeleteMessageBatchCommand(input))
+        let result
+        try {
+          result = await getSQSClient().send(new DeleteMessageBatchCommand(input))
+        } catch (err) {
+          // Don't let one failed delete batch abort the run and leave jobs
+          // stranded in the 'deleting' state; they are cleaned up at the end of
+          // the pass and any redelivery is guarded by dedup.
+          debug('DeleteMessageBatch error', err)
+          if (this.opt.verbose) {
+            console.error(chalk.red('FAILED_TO_DELETE_BATCH'), { qrl, error: err?.message })
+          } else if (!this.opt.disableLog) {
+            console.log(JSON.stringify({
+              event: 'DELETE_MESSAGES_ERROR',
+              timestamp: start,
+              qrl,
+              count: entries.length,
+              errorName: err?.name,
+              errorMessage: err?.message
+            }))
+          }
+          continue
+        }
         this.stats.sqsCalls++
         if (result.Failed?.length) {
           console.error('FAILED_MESSAGES', result.Failed)

--- a/src/sqs.js
+++ b/src/sqs.js
@@ -3,9 +3,19 @@
  */
 
 import { SQSClient, ListQueuesCommand, GetQueueAttributesCommand, QueueDoesNotExist } from '@aws-sdk/client-sqs'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { basename } from 'path'
 import Debug from 'debug'
 const debug = Debug('qdone:sqs')
+
+// Long-poll receives use WaitTimeSeconds up to the SQS maximum of 20s, so give
+// the socket comfortably more than that before treating it as hung. Without an
+// explicit requestTimeout a silently-dropped TCP connection leaves a receive
+// pending forever — the consumer then leaks that receive's concurrency
+// accounting and eventually goes deaf. connectionTimeout guards the TCP handshake.
+const maxLongPollSeconds = 20
+const requestTimeout = (maxLongPollSeconds + 20) * 1000
+const connectionTimeout = 5000
 
 /**
  * Utility function to return an instantiated, shared SQSClient.
@@ -13,7 +23,9 @@ const debug = Debug('qdone:sqs')
 let client
 export function getSQSClient () {
   if (client) return client
-  client = new SQSClient()
+  client = new SQSClient({
+    requestHandler: new NodeHttpHandler({ connectionTimeout, requestTimeout })
+  })
   return client
 }
 

--- a/test/consumer.test.js
+++ b/test/consumer.test.js
@@ -1,0 +1,104 @@
+import { jest } from '@jest/globals'
+import {
+  ReceiveMessageCommand,
+  GetQueueUrlCommand,
+  QueueDoesNotExist,
+  ChangeMessageVisibilityBatchCommand,
+  DeleteMessageBatchCommand
+} from '@aws-sdk/client-sqs'
+import { mockClient } from 'aws-sdk-client-mock'
+
+// The scheduler throttles how many receives it issues based on live event-loop
+// latency, system load and free memory. On a busy host those factors pin the
+// throughput to zero, so we neutralize them to make the receive behavior
+// deterministic and machine-independent — this test is about accounting, not
+// backpressure.
+jest.unstable_mockModule('os', () => {
+  const os = {
+    freemem: () => 16e9,
+    totalmem: () => 16e9,
+    cpus: () => new Array(4).fill({ model: 'mock' })
+  }
+  return { ...os, default: os }
+})
+jest.unstable_mockModule('../src/scheduler/systemMonitor.js', () => ({
+  SystemMonitor: class {
+    getLatency () { return 1 }
+    getLoad () { return 0 }
+    shutdown () {}
+  }
+}))
+
+const { processMessages, requestShutdown } = await import('../src/consumer.js')
+const { getSQSClient, setSQSClient } = await import('../src/sqs.js')
+const { qrlCacheClear } = await import('../src/qrlCache.js')
+
+const BASE_URL = 'https://sqs.us-east-1.amazonaws.com/123456/'
+const N_GEN = 15
+const N_QDNE = 15
+
+let sqsMock
+let result
+
+// One shared run of the scheduler drives every assertion below. Every receive
+// fails: half with a generic error, half with QueueDoesNotExist (the
+// idle-queue-GC case). Both must release their concurrency accounting so the
+// queues stay in rotation instead of the worker going permanently deaf.
+async function runScenario () {
+  qrlCacheClear()
+  const client = getSQSClient()
+  sqsMock = mockClient(client)
+  setSQSClient(sqsMock)
+  sqsMock.on(ChangeMessageVisibilityBatchCommand).resolves({ Successful: [], Failed: [] })
+  sqsMock.on(DeleteMessageBatchCommand).resolves({ Successful: [], Failed: [] })
+  sqsMock.on(GetQueueUrlCommand).callsFake((input) => ({ QueueUrl: BASE_URL + input.QueueName }))
+  sqsMock.on(ReceiveMessageCommand).callsFake((input) => {
+    if (input.QueueUrl.includes('_qdne_')) throw new QueueDoesNotExist({ $metadata: {}, message: 'gone' })
+    throw new Error('simulated receive failure')
+  })
+
+  const names = []
+  for (let i = 0; i < N_GEN; i++) names.push('gen_' + i)
+  for (let i = 0; i < N_QDNE; i++) names.push('qdne_' + i)
+
+  // Fire-and-forget; the loop only exits on requestShutdown.
+  processMessages(names, async () => {}, { maxConcurrentJobs: 100, disableLog: true })
+  await new Promise((resolve) => setTimeout(resolve, 2500))
+  await requestShutdown()
+  await new Promise((resolve) => setTimeout(resolve, 600))
+
+  const urls = sqsMock.commandCalls(ReceiveMessageCommand).map((c) => c.args[0].input.QueueUrl)
+  return {
+    total: urls.length,
+    distinct: new Set(urls).size,
+    distinctGen: new Set(urls.filter((u) => u.includes('_gen_'))).size,
+    distinctQdne: new Set(urls.filter((u) => u.includes('_qdne_'))).size
+  }
+}
+
+afterAll(() => {
+  sqsMock?.restore()
+})
+
+describe('processMessages receive-error accounting', () => {
+  // Runs the shared scenario. A buggy rethrow out of the fire-and-forget
+  // listen() would surface as an unhandled rejection during this test body,
+  // which jest fails the test on — that is the assertion for this case.
+  test('a receive error never surfaces as an unhandled rejection', async () => {
+    result = await runScenario()
+    expect(result.total).toBeGreaterThan(0) // sanity: the scenario actually polled
+  }, 20000)
+
+  test('a receive error keeps the queue in rotation and does not leak concurrency', () => {
+    // If listeningQrls / maxReturnCount leaked, allowedJobs would pin to 0 and
+    // polling would halt after ~10 receives; the fix keeps every queue pollable.
+    expect(result.distinct).toBeGreaterThanOrEqual(20)
+    expect(result.distinctGen).toBeGreaterThanOrEqual(10)
+  })
+
+  test('QueueDoesNotExist releases accounting too', () => {
+    // The old catch backed off on QueueDoesNotExist but still leaked both
+    // counters; every deleted queue must now be pollable again.
+    expect(result.distinctQdne).toBeGreaterThanOrEqual(10)
+  })
+})

--- a/test/consumerOverlap.test.js
+++ b/test/consumerOverlap.test.js
@@ -1,0 +1,76 @@
+import { jest } from '@jest/globals'
+import {
+  ReceiveMessageCommand,
+  GetQueueUrlCommand,
+  ChangeMessageVisibilityBatchCommand,
+  DeleteMessageBatchCommand
+} from '@aws-sdk/client-sqs'
+import { mockClient } from 'aws-sdk-client-mock'
+
+// Neutralize latency/load/memory backpressure so scheduler behavior is
+// deterministic and machine-independent — this test is about queue rotation,
+// not backpressure.
+jest.unstable_mockModule('os', () => {
+  const os = {
+    freemem: () => 16e9,
+    totalmem: () => 16e9,
+    cpus: () => new Array(4).fill({ model: 'mock' })
+  }
+  return { ...os, default: os }
+})
+jest.unstable_mockModule('../src/scheduler/systemMonitor.js', () => ({
+  SystemMonitor: class {
+    getLatency () { return 1 }
+    getLoad () { return 0 }
+    shutdown () {}
+  }
+}))
+
+const { processMessages, requestShutdown } = await import('../src/consumer.js')
+const { getSQSClient, setSQSClient } = await import('../src/sqs.js')
+const { qrlCacheClear } = await import('../src/qrlCache.js')
+
+const BASE_URL = 'https://sqs.us-east-1.amazonaws.com/123456/'
+
+let sqsMock
+
+afterAll(() => {
+  sqsMock?.restore()
+})
+
+// A successful receive must release the queue for further receives while its
+// batch is still executing. Holding the queue "listening" until its slowest
+// job finishes would serialize a hot queue into batch lockstep.
+test('receives on the same queue overlap with job execution', async () => {
+  qrlCacheClear()
+  const client = getSQSClient()
+  sqsMock = mockClient(client)
+  setSQSClient(sqsMock)
+  sqsMock.on(ChangeMessageVisibilityBatchCommand).resolves({ Successful: [], Failed: [] })
+  sqsMock.on(DeleteMessageBatchCommand).resolves({ Successful: [], Failed: [] })
+  sqsMock.on(GetQueueUrlCommand).callsFake((input) => ({ QueueUrl: BASE_URL + input.QueueName }))
+
+  let nextMessageId = 0
+  sqsMock.on(ReceiveMessageCommand).callsFake(() => ({
+    Messages: new Array(10).fill(null).map(() => ({
+      MessageId: 'm-' + nextMessageId,
+      ReceiptHandle: 'rh-' + nextMessageId++,
+      Body: 'noop'
+    }))
+  }))
+
+  // Every job blocks on the gate, so the first batch is still executing while
+  // the scheduler decides whether to poll the queue again.
+  let releaseJobs
+  const gate = new Promise((resolve) => { releaseJobs = resolve })
+  processMessages(['overlap'], () => gate, { maxConcurrentJobs: 100, disableLog: true })
+
+  // The scheduler loop ticks every 300ms; give it several ticks.
+  await new Promise((resolve) => setTimeout(resolve, 1200))
+  const receives = sqsMock.commandCalls(ReceiveMessageCommand).length
+  releaseJobs()
+  await requestShutdown()
+  await new Promise((resolve) => setTimeout(resolve, 600))
+
+  expect(receives).toBeGreaterThanOrEqual(2)
+}, 20000)

--- a/test/jobExecutor.test.js
+++ b/test/jobExecutor.test.js
@@ -615,3 +615,52 @@ describe('JobExecutor kill-after', () => {
     ).rejects.toThrow('jobExecutor is shutting down so cannot execute new jobs')
   })
 })
+
+describe('JobExecutor maintainVisibility resilience', () => {
+  let sqsMock
+
+  beforeEach(() => {
+    shutdownCache()
+    sqsMock = mockClient(client)
+    setSQSClient(sqsMock)
+    sqsMock.on(ChangeMessageVisibilityCommand).resolves({})
+    sqsMock.on(ChangeMessageVisibilityBatchCommand).resolves({ Successful: [], Failed: [] })
+    sqsMock.on(DeleteMessageBatchCommand).resolves({ Successful: [], Failed: [] })
+  })
+
+  afterEach(() => {
+    cleanupExecutors()
+    jest.useRealTimers()
+    sqsMock.restore()
+  })
+
+  afterAll(shutdownCache)
+
+  test('a failing DeleteMessageBatch does not abort the run or strand the job', async () => {
+    sqsMock.on(DeleteMessageBatchCommand).rejects(new Error('sqs unavailable'))
+    const executor = makeExecutor()
+    const job = executor.addJob(makeMessage('del-fail'), async () => {}, 'sdqd_testqueue', 'https://sqs/sdqd_testqueue')
+    job.status = 'complete' // maintainVisibility will try to delete it
+
+    await expect(executor.maintainVisibility()).resolves.toBeUndefined()
+
+    // Not left stranded in the 'deleting' state; cleaned up at the end of the pass.
+    expect(executor.jobs).toHaveLength(0)
+    expect(executor.jobsByMessageId[job.message.MessageId]).toBeUndefined()
+  })
+
+  test('a failing ChangeMessageVisibilityBatch does not abort the maintenance run', async () => {
+    sqsMock.on(ChangeMessageVisibilityBatchCommand).rejects(new Error('sqs unavailable'))
+    const executor = makeExecutor()
+    const job = executor.addJob(makeMessage('ext-fail'), async () => {}, 'sdqd_testqueue', 'https://sqs/sdqd_testqueue')
+    job.status = 'running'
+    job.start = new Date(Date.now() - 3600 * 1000) // long ago, so it is due for extension
+    job.executionStart = new Date()
+
+    await expect(executor.maintainVisibility()).resolves.toBeUndefined()
+
+    // Still tracked and running; a batch failure must not drop the job.
+    expect(executor.jobs).toContain(job)
+    expect(job.status).toBe('running')
+  })
+})


### PR DESCRIPTION
Fixes #114.

## Bug

A `ReceiveMessage` failure in the consumer leaked its concurrency accounting: `maxReturnCount` and the `listeningQrls` entry were only released on the success path, and non-`QueueDoesNotExist` errors were rethrown out of a fire-and-forget `listen()` call (surfacing as unhandled rejections). Enough leaked receives pin `allowedJobs` to 0 and mark every queue as already-polled — the worker stops receiving from all queues while the process still looks healthy.

Observed in production 2026-07-22: the daily idle-queue GC deleted queues that five workers were actively long-polling, producing a synchronized `QueueDoesNotExist` burst that pushed all five past the leak threshold at once (silent receive death).

## Fix

- **`src/consumer.js`** — reserve accounting up front and release it in a `finally`, so no error path (including a hung socket) can leak it. Receive errors now back the queue off through the icehouse and are logged (`RECEIVE_ERROR`) instead of rethrown into the void; `QueueDoesNotExist` stays quiet as the expected result of idle-queue GC.
- **`src/sqs.js`** — explicit `connectionTimeout` (5s) / `requestTimeout` (40s, comfortably above the 20s long-poll max) on the shared SQS client, so a silently-dropped TCP connection can't leave a receive pending forever.
- **`src/scheduler/jobExecutor.js`** — same bug class in maintenance: a single failed `ChangeMessageVisibilityBatch` / `DeleteMessageBatch` call no longer aborts the whole run and strands the remaining queues; it logs and continues.

## Verification

- Full suite 247/247 green (`npm test`), `standard` clean.
- Bite-proven: with `src/consumer.js` reverted to master, exactly the 3 new consumer tests fail (unhandled-rejection trap, queue-stays-in-rotation, QueueDoesNotExist-releases-accounting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)