### PR TITLE
v2.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+v2.2.7 (July 2026)
+-----------------------
+
+### Bug Fixes
+
+- **Release consumer receive accounting on every path; add SQS client timeouts** ([#115](https://github.com/suredone/qdone/pull/115)) — A `ReceiveMessage` failure in `consumer.js` leaked its concurrency accounting: `maxReturnCount` and the `listeningQrls` entry were only released on the success path, and non-`QueueDoesNotExist` errors were rethrown out of a fire-and-forget `listen()` call as unhandled rejections. Enough leaked receives pin `allowedJobs` to 0 and mark every queue as already-polled, so the worker stops receiving from all queues while the process still looks healthy. Reserves accounting up front and releases it in a `finally`, backs the queue off through the icehouse and logs (`RECEIVE_ERROR`) instead of rethrowing, adds explicit `connectionTimeout`/`requestTimeout` to the shared SQS client so a silently-dropped socket can't leave a receive pending forever, and hardens `jobExecutor.js` maintenance so a single failed visibility/delete batch call no longer aborts the run for the remaining queues. Observed in production 2026-07-22 as a synchronized five-host silent receive death following a routine idle-queue GC burst. Closes [#114](https://github.com/suredone/qdone/issues/114).
+
 v2.2.6 (March 2026)
 -----------------------
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "qdone",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qdone",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "3.465.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qdone",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "A distributed scheduler for SQS",
   "type": "module",
   "main": "./index.js",


### PR DESCRIPTION
Release-cut commit for v2.2.7: bumps `package.json` version, regenerates `npm-shrinkwrap.json`, and adds the CHANGELOG entry for the consumer receive-accounting leak fix (#114, PR #115), merged to master at daeebcd.

Mechanical release PR per RELEASING.md. Full suite: 248/248 passing (`npm test`).